### PR TITLE
Various improvements on enemy points

### DIFF
--- a/lib/libbol.py
+++ b/lib/libbol.py
@@ -247,22 +247,35 @@ class ColorRGBA(ColorRGB):
 # Section 1
 # Enemy/Item Route Code Start
 class EnemyPoint(object):
-    def __init__(self, position, pointsetting, link, scale, groupsetting, group, pointsetting2, unk1=0, unk2=0):
+
+    def __init__(self,
+                 position,
+                 driftdirection,
+                 link,
+                 scale,
+                 groupsetting,
+                 group,
+                 driftacuteness,
+                 driftduration,
+                 unknown):
         self.position = position
-        self.pointsetting = pointsetting
+        self.driftdirection = driftdirection
         self.link = link
         self.scale = scale
         self.groupsetting = groupsetting
         self.group = group
-        self.pointsetting2 = pointsetting2
-        self.unk1 = unk1
-        self.unk2 = unk2
+        self.driftacuteness = driftacuteness
+        self.driftduration = driftduration
+        self.unknown = unknown
+
+        assert self.driftdirection in (0, 1, 2)
+        assert 0 <= self.driftacuteness <= 180
 
     @classmethod
     def new(cls):
         return cls(
             Vector3(0.0, 0.0, 0.0),
-            0, -1, 1000.0, 0, 0, 0
+            0, -1, 1000.0, 0, 0, 0, 0, 0
         )
 
     @classmethod
@@ -286,8 +299,8 @@ class EnemyPoint(object):
     def write(self, f):
         start = f.tell()
         f.write(pack(">fff", self.position.x, self.position.y, self.position.z))
-        f.write(pack(">Hhf", self.pointsetting, self.link, self.scale))
-        f.write(pack(">HBBBH", self.groupsetting, self.group, self.pointsetting2, self.unk1, self.unk2))
+        f.write(pack(">Hhf", self.driftdirection, self.link, self.scale))
+        f.write(pack(">HBBBH", self.groupsetting, self.group, self.driftacuteness, self.driftduration, self.unknown))
         f.write(b"\x00"*5)
         #assert f.tell() - start == self._size
 

--- a/lib/libbol.py
+++ b/lib/libbol.py
@@ -253,7 +253,8 @@ class EnemyPoint(object):
                  driftdirection,
                  link,
                  scale,
-                 groupsetting,
+                 swerve,
+                 itemsonly,
                  group,
                  driftacuteness,
                  driftduration,
@@ -262,12 +263,15 @@ class EnemyPoint(object):
         self.driftdirection = driftdirection
         self.link = link
         self.scale = scale
-        self.groupsetting = groupsetting
+        self.swerve = swerve
+        self.itemsonly = itemsonly
         self.group = group
         self.driftacuteness = driftacuteness
         self.driftduration = driftduration
         self.unknown = unknown
 
+        assert self.swerve in (-3, -2, -1, 0, 1, 2, 3)
+        assert self.itemsonly in (0, 1)
         assert self.driftdirection in (0, 1, 2)
         assert 0 <= self.driftacuteness <= 180
 
@@ -275,7 +279,7 @@ class EnemyPoint(object):
     def new(cls):
         return cls(
             Vector3(0.0, 0.0, 0.0),
-            0, -1, 1000.0, 0, 0, 0, 0, 0
+            0, -1, 1000.0, 0, 0, 0, 0, 0, 0
         )
 
     @classmethod
@@ -283,7 +287,7 @@ class EnemyPoint(object):
         start = f.tell()
         args = [Vector3(*unpack(">fff", f.read(12)))]
         if not old_bol:
-            args.extend(unpack(">HhfHBBBH", f.read(15)))
+            args.extend(unpack(">HhfbBBBBH", f.read(15)))
             padding = f.read(5)  # padding
             assert padding == b"\x00" * 5
         else:
@@ -300,7 +304,7 @@ class EnemyPoint(object):
         start = f.tell()
         f.write(pack(">fff", self.position.x, self.position.y, self.position.z))
         f.write(pack(">Hhf", self.driftdirection, self.link, self.scale))
-        f.write(pack(">HBBBH", self.groupsetting, self.group, self.driftacuteness, self.driftduration, self.unknown))
+        f.write(pack(">bBBBBH", self.swerve, self.itemsonly, self.group, self.driftacuteness, self.driftduration, self.unknown))
         f.write(b"\x00"*5)
         #assert f.tell() - start == self._size
 
@@ -1254,6 +1258,19 @@ REVERSE_MUSIC_IDS = OrderedDict()
 for key in sorted(MUSIC_IDS.keys()):
     REVERSE_MUSIC_IDS[MUSIC_IDS[key]] = key
 
+
+SWERVE_IDS = {
+    -3: "To the left (-3)",
+    -2: "To the left (-2)",
+    -1: "To the left (-1)",
+    0: "",
+    1: "To the right (1)",
+    2: "To the right (2)",
+    3: "To the right (3)",
+}
+REVERSE_SWERVE_IDS = OrderedDict()
+for key in sorted(SWERVE_IDS.keys()):
+    REVERSE_SWERVE_IDS[SWERVE_IDS[key]] = key
 
 def get_full_name(id):
     if id not in OBJECTNAMES:

--- a/lib/model_rendering.py
+++ b/lib/model_rendering.py
@@ -1,4 +1,5 @@
 import json
+import re
 import sys
 from time import time
 from OpenGL.GL import *
@@ -151,7 +152,7 @@ class Material(object):
             # When SuperBMD is used through Wine, it generates some odd filepaths that need to be
             # corrected.
             if sys.platform != "win32":
-                texturepath = texturepath.replace("lib/temp/Z:", "").replace("\\", "/")
+                texturepath = re.sub("lib/temp/[A-Z]:", "", texturepath).replace("\\", "/")
 
             qimage = QtGui.QImage(texturepath, fmt)
             qimage = qimage.convertToFormat(QtGui.QImage.Format_ARGB32)

--- a/mkdd_widgets.py
+++ b/mkdd_widgets.py
@@ -884,19 +884,19 @@ class BolMapViewer(QtWidgets.QOpenGLWidget):
 
                         self.models.render_generic_position_colored(point.position, point in select_optimize, "enemypoint")
 
-                        if point.pointsetting:
+                        if point.driftdirection:
                             glColor3f(0.9, 0.0, 0.1)
                             self.models.draw_cylinder(point.position, 700, 700)
+                        if point.driftacuteness:
+                            glColor3f(0.1, 0.1, 1.0)
+                            self.models.draw_cylinder(point.position, 600, 600)
+                        if point.driftduration:
+                            glColor3f(0.9, 0.9, 0.1)
+                            self.models.draw_cylinder(point.position, 500, 500)
                         if point.groupsetting:
                             glColor3f(0.1, 0.9, 0.2)
-                            self.models.draw_cylinder(point.position, 600, 600)
-                        if point.pointsetting2:
-                            glColor3f(0.2, 0.2, 0.9)
-                            self.models.draw_cylinder(point.position, 500, 500)
-                        if point.unk1:
-                            glColor3f(0.9, 0.9, 0.1)
                             self.models.draw_cylinder(point.position, 400, 400)
-                        if point.unk2:
+                        if point.unknown:
                             glColor3f(0.9, 0.0, 0.9)
                             self.models.draw_cylinder(point.position, 300, 300)
 

--- a/mkdd_widgets.py
+++ b/mkdd_widgets.py
@@ -884,6 +884,9 @@ class BolMapViewer(QtWidgets.QOpenGLWidget):
 
                         self.models.render_generic_position_colored(point.position, point in select_optimize, "enemypoint")
 
+                        if point.itemsonly:
+                            glColor3f(1.0, 0.5, 0.1)
+                            self.models.draw_cylinder(point.position, 800, 800)
                         if point.driftdirection:
                             glColor3f(0.9, 0.0, 0.1)
                             self.models.draw_cylinder(point.position, 700, 700)
@@ -893,7 +896,7 @@ class BolMapViewer(QtWidgets.QOpenGLWidget):
                         if point.driftduration:
                             glColor3f(0.9, 0.9, 0.1)
                             self.models.draw_cylinder(point.position, 500, 500)
-                        if point.groupsetting:
+                        if point.swerve:
                             glColor3f(0.1, 0.9, 0.2)
                             self.models.draw_cylinder(point.position, 400, 400)
                         if point.unknown:

--- a/widgets/data_editor.py
+++ b/widgets/data_editor.py
@@ -7,7 +7,8 @@ from PyQt5.QtGui import QIntValidator, QDoubleValidator, QValidator
 from math import inf
 from lib.libbol import (EnemyPoint, EnemyPointGroup, CheckpointGroup, Checkpoint, Route, RoutePoint,
                         MapObject, KartStartPoint, Area, Camera, BOL, JugemPoint, MapObject,
-                        LightParam, MGEntry, OBJECTNAMES, REVERSEOBJECTNAMES, MUSIC_IDS, REVERSE_MUSIC_IDS)
+                        LightParam, MGEntry, OBJECTNAMES, REVERSEOBJECTNAMES, MUSIC_IDS, REVERSE_MUSIC_IDS,
+                        SWERVE_IDS, REVERSE_SWERVE_IDS)
 from lib.vectors import Vector3
 from lib.model_rendering import Minimap
 from PyQt5.QtCore import pyqtSignal
@@ -478,8 +479,8 @@ class EnemyPointEdit(DataEditor):
         self.link = self.add_integer_input("Link", "link",
                                            MIN_SIGNED_SHORT, MAX_SIGNED_SHORT)
         self.scale = self.add_decimal_input("Scale", "scale", -inf, inf)
-        self.groupsetting = self.add_integer_input("Group Setting", "groupsetting",
-                                                   MIN_UNSIGNED_SHORT, MAX_UNSIGNED_SHORT)
+        self.itemsonly = self.add_checkbox("Items Only", "itemsonly", off_value=0, on_value=1)
+        self.swerve = self.add_dropdown_input("Swerve", "swerve", REVERSE_SWERVE_IDS)
         self.group = self.add_integer_input("Group", "group",
                                             MIN_UNSIGNED_BYTE, MAX_UNSIGNED_BYTE)
         if not group_editable:
@@ -505,11 +506,18 @@ class EnemyPointEdit(DataEditor):
         self.driftdirection.setCurrentIndex(obj.driftdirection)
         self.link.setText(str(obj.link))
         self.scale.setText(str(obj.scale))
-        self.groupsetting.setText(str(obj.groupsetting))
+        self.itemsonly.setChecked(bool(obj.itemsonly))
         self.group.setText(str(obj.group))
         self.driftacuteness.setText(str(obj.driftacuteness))
         self.driftduration.setText(str(obj.driftduration))
         self.unknown.setText(str(obj.unknown))
+
+        if obj.swerve in SWERVE_IDS:
+            name = SWERVE_IDS[obj.swerve]
+        else:
+            name = SWERVE_IDS[0]
+        index = self.swerve.findText(name)
+        self.swerve.setCurrentIndex(index)
 
 
 class CheckpointGroupEdit(DataEditor):

--- a/widgets/data_editor.py
+++ b/widgets/data_editor.py
@@ -497,6 +497,12 @@ class EnemyPointEdit(DataEditor):
 
         for widget in self.position:
             widget.editingFinished.connect(self.catch_text_update)
+        for widget in (self.itemsonly, ):
+            widget.stateChanged.connect(lambda _state: self.catch_text_update())
+        for widget in (self.swerve, self.driftdirection):
+            widget.currentIndexChanged.connect(lambda _index: self.catch_text_update())
+        for widget in (self.link, self.driftacuteness, self.driftduration, self.unknown):
+            widget.editingFinished.connect(self.catch_text_update)
 
     def update_data(self):
         obj: EnemyPoint = self.bound_to

--- a/widgets/data_editor.py
+++ b/widgets/data_editor.py
@@ -465,12 +465,16 @@ class EnemyPointGroupEdit(DataEditor):
         self.groupid.setText(str(self.bound_to.id))
 
 
+DRIFT_DIRECTION_OPTIONS = OrderedDict()
+DRIFT_DIRECTION_OPTIONS[""] = 0
+DRIFT_DIRECTION_OPTIONS["To the left"] = 1
+DRIFT_DIRECTION_OPTIONS["To the right"] = 2
+
+
 class EnemyPointEdit(DataEditor):
     def setup_widgets(self, group_editable=False):
         self.position = self.add_multiple_decimal_input("Position", "position", ["x", "y", "z"],
                                                         -inf, +inf)
-        self.pointsetting = self.add_integer_input("Point Setting", "pointsetting",
-                                                    MIN_UNSIGNED_SHORT, MAX_UNSIGNED_SHORT)
         self.link = self.add_integer_input("Link", "link",
                                            MIN_SIGNED_SHORT, MAX_SIGNED_SHORT)
         self.scale = self.add_decimal_input("Scale", "scale", -inf, inf)
@@ -481,12 +485,14 @@ class EnemyPointEdit(DataEditor):
         if not group_editable:
             self.group.setDisabled(True)
 
-        self.pointsetting2 = self.add_integer_input("Point Setting 2", "pointsetting2",
+        self.driftdirection = self.add_dropdown_input("Drift Direction", "driftdirection",
+                                                      DRIFT_DIRECTION_OPTIONS)
+        self.driftacuteness = self.add_integer_input("Drift Acuteness", "driftacuteness",
+                                                     MIN_UNSIGNED_BYTE, 180)
+        self.driftduration = self.add_integer_input("Drift Duration", "driftduration",
                                                     MIN_UNSIGNED_BYTE, MAX_UNSIGNED_BYTE)
-        self.unk1 = self.add_integer_input("Unknown 1", "unk1",
-                                           MIN_UNSIGNED_BYTE, MAX_UNSIGNED_BYTE)
-        self.unk2 = self.add_integer_input("Unknown 2", "unk2",
-                                           MIN_UNSIGNED_SHORT, MAX_UNSIGNED_SHORT)
+        self.unknown = self.add_integer_input("Unknown", "unknown",
+                                              MIN_UNSIGNED_SHORT, MAX_UNSIGNED_SHORT)
 
         for widget in self.position:
             widget.editingFinished.connect(self.catch_text_update)
@@ -496,14 +502,14 @@ class EnemyPointEdit(DataEditor):
         self.position[0].setText(str(round(obj.position.x, 3)))
         self.position[1].setText(str(round(obj.position.y, 3)))
         self.position[2].setText(str(round(obj.position.z, 3)))
-        self.pointsetting.setText(str(obj.pointsetting))
+        self.driftdirection.setCurrentIndex(obj.driftdirection)
         self.link.setText(str(obj.link))
         self.scale.setText(str(obj.scale))
         self.groupsetting.setText(str(obj.groupsetting))
         self.group.setText(str(obj.group))
-        self.pointsetting2.setText(str(obj.pointsetting2))
-        self.unk1.setText(str(obj.unk1))
-        self.unk2.setText(str(obj.unk2))
+        self.driftacuteness.setText(str(obj.driftacuteness))
+        self.driftduration.setText(str(obj.driftduration))
+        self.unknown.setText(str(obj.unknown))
 
 
 class CheckpointGroupEdit(DataEditor):


### PR DESCRIPTION
Properties in the enemy points have been reworked:

- **Group Setting** (`groupsetting`) split into **Items only** (`itemsonly`) and **Swerve** (`swerve`).
- **Point Setting** (`pointsetting`) renamed to **Drift Direction** (`driftdirection`).
- **Point Setting 2** (`pointsetting2`) renamed to **Drift Acuteness** (`driftacuteness`).
- **Unknown 1** (`unk1`) renamed to **Drift Duration** (`driftduration`).
- **Unknown 2** (`unk2`) renamed to **Unknown** (`unknown`).

(Only one property remains unknown.)

Combo boxes and check boxes are used for relevant widgets:

![image](https://user-images.githubusercontent.com/1853278/164558719-82f23307-11b6-48be-9a65-d5a549777ce5.png)