### PR TITLE
Draw area boxes using their position as the centroid of their base.

### DIFF
--- a/lib/object_models.py
+++ b/lib/object_models.py
@@ -132,6 +132,7 @@ class ObjectModels(object):
         glTranslatef(position.x, -position.z, position.y)
         mtx = rotation.mtx
         glMultMatrixf(mtx)
+        glTranslatef(0, 0, scale.y / 2)
         glScalef(-scale.z, scale.x, scale.y)
         self.wireframe_cube.render()
         glPopMatrix()


### PR DESCRIPTION
Previously, the area position was used as the center of the area box.

A few before & after comparisons:

<img src="https://user-images.githubusercontent.com/1853278/190271633-7be983ce-f0a3-494a-8e0d-66526b73832e.png" width=480 />
<img src="https://user-images.githubusercontent.com/1853278/190271638-9bf7f240-45aa-4f3b-bcd0-9623a3ff0595.png" width=480 />

<img src="https://user-images.githubusercontent.com/1853278/190271648-280b09c9-0d0d-4e5f-9a84-66c3df16d571.png" width=480 />
<img src="https://user-images.githubusercontent.com/1853278/190271654-bb76a5d1-a569-469b-9464-99efd5874783.png" width=480 />

<img src="https://user-images.githubusercontent.com/1853278/190271659-983f0125-8ed8-4b2e-ad0b-eae3bcb2a9fa.png" width=480 />
<img src="https://user-images.githubusercontent.com/1853278/190271662-3ac1f173-153c-4405-a298-4c63ba4285a8.png" width=480 />

<img src="https://user-images.githubusercontent.com/1853278/190271668-bb7ed976-01d1-4ea7-abc1-e31131885d09.png" width=480 />
<img src="https://user-images.githubusercontent.com/1853278/190271675-58704cea-8348-4773-9bcd-eba36c7a48de.png" width=480 />