### PR TITLE
Added checks before accessing config keys while restoring geometry.

### DIFF
--- a/mkdd_editor.py
+++ b/mkdd_editor.py
@@ -134,9 +134,8 @@ class GenEditor(QMainWindow):
 
     def save_geometry(self):
         if "geometry" not in self.configuration:
-            self.configuration["geometry"] = geo_config = {}
-        else:
-            geo_config = self.configuration["geometry"]
+            self.configuration["geometry"] = {}
+        geo_config = self.configuration["geometry"]
 
         def to_base64(byte_array: QtCore.QByteArray) -> str:
             return bytes(byte_array.toBase64()).decode(encoding='ascii')
@@ -159,9 +158,12 @@ class GenEditor(QMainWindow):
         def to_byte_array(byte_array: str) -> QtCore.QByteArray:
             return QtCore.QByteArray.fromBase64(byte_array.encode(encoding='ascii'))
 
-        self.restoreGeometry(to_byte_array(geo_config["window_geometry"]))
-        self.restoreState(to_byte_array(geo_config["window_state"]))
-        self.horizontalLayout.restoreState(to_byte_array(geo_config["window_splitter"]))
+        if "window_geometry" in geo_config:
+            self.restoreGeometry(to_byte_array(geo_config["window_geometry"]))
+        if "window_state" in geo_config:
+            self.restoreState(to_byte_array(geo_config["window_state"]))
+        if "window_splitter" in geo_config:
+            self.horizontalLayout.restoreState(to_byte_array(geo_config["window_splitter"]))
 
     def closeEvent(self, event: QtGui.QCloseEvent):
         self.save_geometry()


### PR DESCRIPTION
This fixes a regression introduced as part of https://github.com/RenolY2/mkdd-track-editor/commit/2667774fb676e692bc8dcabba0be5208989b0026.

Reproduction steps:

- Launch the editor from a fresh installation (or erase the `editor_config.ini` file).
- Close the editor without any interaction.
- Launch the editor again. A *fatal* exception is produced:
```
Traceback (most recent call last):
  File "mkdd_editor.py", line 2290, in <module>
    editor_gui = GenEditor()
  File "mkdd_editor.py", line 133, in __init__
    self.restore_geometry()
  File "mkdd_editor.py", line 162, in restore_geometry
    self.restoreGeometry(to_byte_array(geo_config["window_geometry"]))
  File "/usr/lib/python3.8/configparser.py", line 1254, in __getitem__
    raise KeyError(key)
KeyError: 'window_geometry'
```