### PR TITLE
Distinct route colors and general route labels.

### DIFF
--- a/lib/color_coding.json
+++ b/lib/color_coding.json
@@ -1,6 +1,9 @@
 {
   "EnemyRoutes": [0.7, 0.7, 0.7, 1.0],
-  "ItemRoutes": [0.0, 0.8, 0.0, 1.0],
+  "ObjectRoutes": [0.0, 0.8, 0.0, 1.0],
+  "CameraRoutes": [0.749, 0.48, 0.19, 1.0],
+  "UnassignedRoutes": [0.85, 0.85, 0.85, 1.0],
+  "SharedRoutes": [1.0, 0.0, 1.0, 1.0],
   "CheckpointLeft": [1.0, 0.0, 0.0, 1.0],
   "CheckpointRight": [0.1, 0.1, 0.8, 1.0],
   "SelectionColor": [1.0, 0.874, 0.153, 1.0],

--- a/lib/object_models.py
+++ b/lib/object_models.py
@@ -21,7 +21,10 @@ class ObjectModels(object):
         self.cube = Cube()
         self.checkpointleft = Cube(colors["CheckpointLeft"])
         self.checkpointright = Cube(colors["CheckpointRight"])
-        self.itempoint = Cube(colors["ItemRoutes"])
+        self.objectroute = Cube(colors["ObjectRoutes"])
+        self.cameraroute = Cube(colors["CameraRoutes"])
+        self.unassignedroute = Cube(colors["UnassignedRoutes"])
+        self.sharedroute = Cube(colors["SharedRoutes"])
         self.enemypoint = Cube(colors["EnemyRoutes"])
         self.camera = GenericObject(colors["Camera"])
         self.areas = GenericObject(colors["Areas"])
@@ -74,8 +77,9 @@ class ObjectModels(object):
                     filename = os.path.basename(file)
                     objectname = filename.rsplit(".", 1)[0]
                     self.models[objectname] = TexturedModel.from_obj_path(os.path.join(dirpath, file), rotate=True)
-        for cube in (self.cube, self.checkpointleft, self.checkpointright, self.itempoint, self.enemypoint,
-                     self.objects, self.areas, self.respawn, self.startpoints, self.camera):
+        for cube in (self.cube, self.checkpointleft, self.checkpointright, self.objectroute, self.cameraroute,
+                     self.unassignedroute, self.sharedroute, self.enemypoint, self.objects, self.areas, self.respawn,
+                     self.startpoints, self.camera):
             cube.generate_displists()
 
         for cube in self.playercolors:

--- a/mkdd_editor.py
+++ b/mkdd_editor.py
@@ -2084,8 +2084,8 @@ class GenEditor(QMainWindow):
                             break
 
                 elif isinstance(currentobj, libbol.RoutePoint):
-                    for i in range(self.leveldatatreeview.objectroutes.childCount()):
-                        child = self.leveldatatreeview.objectroutes.child(i)
+                    for i in range(self.leveldatatreeview.routes.childCount()):
+                        child = self.leveldatatreeview.routes.child(i)
                         item = get_treeitem(child, currentobj)
                         if item is not None:
                             break

--- a/mkdd_editor.py
+++ b/mkdd_editor.py
@@ -292,10 +292,24 @@ class GenEditor(QMainWindow):
             for enemy_path in self.level_file.enemypointgroups.groups:
                 for enemy_path_point in enemy_path.points:
                     extend(enemy_path_point.position)
-        if self.visibility_menu.itemroutes.is_visible():
-            for object_route in self.level_file.routes:
+
+        visible_objectroutes = self.visibility_menu.objectroutes.is_visible()
+        visible_cameraroutes = self.visibility_menu.cameraroutes.is_visible()
+        visible_unassignedroutes = self.visibility_menu.unassignedroutes.is_visible()
+
+        if visible_objectroutes or visible_cameraroutes or visible_unassignedroutes:
+            camera_routes = set(camera.route for camera in self.level_file.cameras)
+            object_routes = set(obj.pathid for obj in self.level_file.objects.objects)
+            assigned_routes = camera_routes.union(object_routes)
+
+            for i, object_route in enumerate(self.level_file.routes):
+                if (not ((i in object_routes and visible_objectroutes) or
+                         (i in camera_routes and visible_cameraroutes) or
+                         (i not in assigned_routes and visible_unassignedroutes))):
+                    continue
                 for object_route_point in object_route.points:
                     extend(object_route_point.position)
+
         if self.visibility_menu.checkpoints.is_visible():
             for checkpoint_group in self.level_file.checkpoints.groups:
                 for checkpoint in checkpoint_group.points:

--- a/widgets/data_editor.py
+++ b/widgets/data_editor.py
@@ -700,13 +700,13 @@ class ObjectEdit(DataEditor):
         self.rotation = self.add_rotation_input()
         self.objectid = self.add_dropdown_input("Object Type", "objectid", REVERSEOBJECTNAMES)
 
-        self.pathid = self.add_integer_input("Object Path ID", "pathid",
+        self.pathid = self.add_integer_input("Route ID", "pathid",
                                              MIN_SIGNED_SHORT, MAX_SIGNED_SHORT)
 
         self.unk_28 = self.add_integer_input("Unknown 0x28", "unk_28",
                                              MIN_UNSIGNED_SHORT, MAX_UNSIGNED_SHORT)
 
-        self.unk_2a = self.add_integer_input("Object Path Point ID", "unk_2a",
+        self.unk_2a = self.add_integer_input("Route Point ID", "unk_2a",
                                              MIN_SIGNED_SHORT, MAX_SIGNED_SHORT)
         self.presence_filter = self.add_integer_input("Presence Mask", "presence_filter",
                                                       MIN_UNSIGNED_BYTE, MAX_UNSIGNED_BYTE)
@@ -907,7 +907,7 @@ class CameraEdit(DataEditor):
                                            MIN_UNSIGNED_SHORT, MAX_UNSIGNED_SHORT)
         self.unk3 = self.add_integer_input("Unknown 3", "unk3",
                                            MIN_UNSIGNED_SHORT, MAX_UNSIGNED_SHORT)
-        self.route = self.add_integer_input("Object Path ID", "route",
+        self.route = self.add_integer_input("Route ID", "route",
                                             MIN_SIGNED_SHORT, MAX_SIGNED_SHORT)
         self.routespeed = self.add_integer_input("Route Speed", "routespeed",
                                                  MIN_UNSIGNED_SHORT, MAX_UNSIGNED_SHORT)

--- a/widgets/editor_widgets.py
+++ b/widgets/editor_widgets.py
@@ -329,7 +329,7 @@ class AddPikObjectWindow(QMdiSubWindow):
         self.objecttypes = {
             "Enemy Point": libbol.EnemyPoint,
             "Checkpoint": libbol.Checkpoint,
-            "Object Point": libbol.RoutePoint,
+            "Route Point": libbol.RoutePoint,
             "Object": libbol.MapObject,
             "Area": libbol.Area,
             "Camera": libbol.Camera,
@@ -337,7 +337,7 @@ class AddPikObjectWindow(QMdiSubWindow):
             "Kart Start Point": libbol.KartStartPoint,
             "Enemy Path": libbol.EnemyPointGroup,
             "Checkpoint Group": libbol.CheckpointGroup,
-            "Object Path": libbol.Route,
+            "Route": libbol.Route,
             "Light Param": libbol.LightParam,
             "Minigame Param": libbol.MGEntry
         }

--- a/widgets/editor_widgets.py
+++ b/widgets/editor_widgets.py
@@ -342,7 +342,7 @@ class AddPikObjectWindow(QMdiSubWindow):
             "Minigame Param": libbol.MGEntry
         }
 
-        for item, val in self.objecttypes.items():
+        for item in sorted(self.objecttypes.keys()):
             self.category_menu.addItem(item)
 
         self.category_menu.currentIndexChanged.connect(self.change_category)

--- a/widgets/tree_view.py
+++ b/widgets/tree_view.py
@@ -69,12 +69,12 @@ class CheckpointGroup(ObjectGroup):
 
 class ObjectPointGroup(ObjectGroup):
     def __init__(self, parent, bound_to):
-        super().__init__("Object Path", parent=parent, bound_to=bound_to)
+        super().__init__("Route", parent=parent, bound_to=bound_to)
         self.update_name()
 
     def update_name(self):
         index = self.parent().indexOfChild(self)
-        self.setText(0, "Object Path {0}".format(index))
+        self.setText(0, "Route {0}".format(index))
 
 
 # Entries in groups or entries without groups
@@ -148,7 +148,7 @@ class ObjectRoutePoint(NamedItem):
 
         index = group.points.index(self.bound_to)
 
-        self.setText(0, "Object Point {0}".format(index))
+        self.setText(0, "Route Point {0}".format(index))
 
 
 class ObjectEntry(NamedItem):
@@ -220,7 +220,7 @@ class LevelDataTreeView(QTreeWidget):
 
         self.enemyroutes = self._add_group("Enemy Paths")
         self.checkpointgroups = self._add_group("Checkpoint Groups")
-        self.objectroutes = self._add_group("Object Paths")
+        self.routes = self._add_group("Routes")
         self.objects = self._add_group("Objects", ObjectGroupObjects)
         self.kartpoints = self._add_group("Kart Start Points")
         self.areas = self._add_group("Areas")
@@ -310,7 +310,7 @@ class LevelDataTreeView(QTreeWidget):
     def reset(self):
         self.enemyroutes.remove_children()
         self.checkpointgroups.remove_children()
-        self.objectroutes.remove_children()
+        self.routes.remove_children()
         self.objects.remove_children()
         self.kartpoints.remove_children()
         self.areas.remove_children()
@@ -335,10 +335,10 @@ class LevelDataTreeView(QTreeWidget):
                 point_item = Checkpoint(group_item, "Checkpoint", point)
 
         for route in boldata.routes:
-            route_item = ObjectPointGroup(self.objectroutes, route)
+            route_item = ObjectPointGroup(self.routes, route)
 
             for point in route.points:
-                point_item = ObjectRoutePoint(route_item, "Object route point", point)
+                point_item = ObjectRoutePoint(route_item, "Route Point", point)
 
         for object in boldata.objects.objects:
             object_item = ObjectEntry(self.objects, "Object", object)


### PR DESCRIPTION
The "Object Routes" and "Object Paths" labels have been changed to a more general "Routes" label. Rationale: Since these routes can be assigned to ~~either~~ both objects and cameras, utilizing a common name "routes" is more adequate. It is also shorter.

Distinct colors are now used to draw the routes, depending on what entity they have been assigned to:

- Assigned to objects: green (same as before)
- Assigned to cameras: brownish pink (saturated camera color)
- Unassigned: light gray
- Assigned to both objects and cameras: fuchsia

Before and after comparison:

<img src="https://user-images.githubusercontent.com/1853278/191595902-8fa8f25e-6327-4219-99b3-d3f297cd0032.png" width="280"/>
<img src="https://user-images.githubusercontent.com/1853278/191595918-5b20100a-727a-4501-9795-c60985890639.png" width="280"/>


Also, the **Filter View** menu now shows six different check boxes, so that the user can hide/disable the set that is not being worked on:

- **Object Routes visible**
- **Object Routes selectable**
- **Camera Routes visible**
- **Camera Routes selectable**
- **Unassigned Routes visible**
- **Unassigned Routes selectable**

![Visibility check boxes for routes](https://user-images.githubusercontent.com/1853278/191596833-3a4909ec-2693-4bcb-a709-ecebe1a51a28.png)



