### PR TITLE
Removed `step` in the marquee selection's `for` loop to favor accuracy.

### DIFF
--- a/mkdd_widgets.py
+++ b/mkdd_widgets.py
@@ -731,35 +731,33 @@ class BolMapViewer(QtWidgets.QOpenGLWidget):
                 #for i in range(0, clickwidth*clickheight, 4):
                 start = default_timer()
 
-                for i in range(0, clickwidth*clickheight, 13):
-                        # | (pixels[i*3+0] << 16)
-                        if pixels[i * 3] != 0xFF:
-                            upper = pixels[i * 3] & 0x0F
-                            index = (upper << 16)| (pixels[i*3 + 1] << 8) | pixels[i*3 + 2]
-                            if index & 0b1:
-                                # second position
-                                entry = objlist[index//4]
-                                if entry[0] not in selected:
-                                    selected[entry[0]] = 2
+                indexes = set()
+                for i in range(0, clickwidth * clickheight):
+                    if pixels[i * 3] != 0xFF:
+                        upper = pixels[i * 3] & 0x0F
+                        index = (upper << 16) | (pixels[i * 3 + 1] << 8) | pixels[i * 3 + 2]
+                        indexes.add(index)
 
-                                    selected_positions.append(entry[2])
-                                elif selected[entry[0]] == 1:
-                                    selected[entry[0]] = 3
-                                    selected_positions.append(entry[2])
-                            else:
-                                entry = objlist[index // 4]
-                                if entry[0] not in selected:
-                                    selected[entry[0]] = 1
+                for index in indexes:
+                    entry = objlist[index // 4]
+                    obj = entry[0]
 
-                                    selected_positions.append(entry[1])
-
-                                    if index & 0b10:
-                                        print("found a rotation")
-                                        selected_rotations.append(entry[3])
-
-                                elif selected[entry[0]] == 2:
-                                    selected[entry[0]] = 3
-                                    selected_positions.append(entry[1])
+                    if index & 0b1:
+                        if obj not in selected:
+                            selected[obj] = 2
+                            selected_positions.append(entry[2])
+                        elif selected[obj] == 1:
+                            selected[obj] = 3
+                            selected_positions.append(entry[2])
+                    else:
+                        if obj not in selected:
+                            selected[obj] = 1
+                            selected_positions.append(entry[1])
+                            if index & 0b10:
+                                selected_rotations.append(entry[3])
+                        elif selected[obj] == 2:
+                            selected[obj] = 3
+                            selected_positions.append(entry[1])
 
                 #print("select time taken", default_timer() - start)
                 #print("result:", selected)


### PR DESCRIPTION
The `step` had been added to reduce the number of samples in the loop, increasing performance at the expense of accuracy.

After using a `set` to discard duplicates, removing the debug `print` statement, and some other trivial, minor tweaks, performance seems to hold well, even when testing all pixels.

Local tests (`1920x1080` viewport, and a `1920x1080` marquee selection, and the stock Bowser's Castle track fully framed) show that the loop can take as long as `180 ms`, which will cause a slightly delay.

However, this can be considered an edge case, as not often will users try to select all objects this way. The common case (a small marquee selection) should still be fast, _and now also accurate_.