### PR TITLE
Enable default lighting for textured models.

### DIFF
--- a/lib/model_rendering.py
+++ b/lib/model_rendering.py
@@ -96,9 +96,23 @@ class TexturedMesh(object):
 
         for triangle in self.triangles:
             assert len(triangle) == 3
+
+            # At this time, SuperBMD does not export vertex normals in the OBJ file. For now, a
+            # generated normal for the triangle will be provided.
+            v0 = Vector3(*self.vertex_positions[triangle[0][0]])
+            v1 = Vector3(*self.vertex_positions[triangle[1][0]])
+            v2 = Vector3(*self.vertex_positions[triangle[2][0]])
+            vn = (v1 - v0).cross(v2 - v0)
+            if not vn.norm():
+                # Implies that the points of the faces are colinear (don't form a triangle) and
+                # can be skipped. Several of these have been spotted in the stock Bowser's Castle.
+                continue
+            vn.normalize()
+
             for vi, ti in triangle:
                 if self.material.tex is not None and ti is not None:
                     glTexCoord2f(*self.vertex_texcoords[ti])
+                glNormal3f(vn.x, vn.y, vn.z)
                 glVertex3f(*self.vertex_positions[vi])
 
         glEnd()

--- a/mkdd_widgets.py
+++ b/mkdd_widgets.py
@@ -807,10 +807,28 @@ class BolMapViewer(QtWidgets.QOpenGLWidget):
             if self.alternative_mesh is None:
                 glCallList(self.main_model)
             else:
+                if self.mode != MODE_TOPDOWN:
+                    light0_position = (campos.x, -campos.z, campos.y, 1.0)
+                    light0_diffuse = (5.0, 5.0, 5.0, 1.0)
+                    light0_specular = (0.8, 0.8, 0.8, 1.0)
+                    light0_ambient = (1.8, 1.8, 1.8, 1.0)
+                    glLightfv(GL_LIGHT0, GL_POSITION, light0_position)
+                    glLightfv(GL_LIGHT0, GL_DIFFUSE, light0_diffuse)
+                    glLightfv(GL_LIGHT0, GL_DIFFUSE, light0_specular)
+                    glLightfv(GL_LIGHT0, GL_AMBIENT, light0_ambient)
+                    glShadeModel(GL_SMOOTH)
+                    glEnable(GL_LIGHT0)
+                    glEnable(GL_RESCALE_NORMAL)
+                    glEnable(GL_NORMALIZE)
+                    glEnable(GL_LIGHTING)
+
                 glPushMatrix()
                 glScalef(1.0, -1.0, 1.0)
                 self.alternative_mesh.render(selectedPart=self.highlight_colltype)
                 glPopMatrix()
+
+                if self.mode != MODE_TOPDOWN:
+                    glDisable(GL_LIGHTING)
 
         glDisable(GL_TEXTURE_2D)
         glColor4f(1.0, 1.0, 1.0, 1.0)


### PR DESCRIPTION
Default GL lighting (OpenGL 2.1) is now used for the textured geometry.

Comparison before and after:

<img src="https://user-images.githubusercontent.com/1853278/194706986-dd1407b6-300d-4e3a-bc55-7a25b3fcb568.png" alt="No lighting" title="No lighting" width="480"/>
<img src="https://user-images.githubusercontent.com/1853278/194706996-3b6134ef-eec4-4b1b-87b9-29f978804d19.png" alt="Lighting" title="Lighting" width="480"/>
