### PR TITLE
Auto-determine starting point count based on the actual starting point entries.

### DIFF
--- a/lib/libbol.py
+++ b/lib/libbol.py
@@ -982,7 +982,7 @@ class BOL(object):
         self.unk1 = 0
         self.unk2 = 0
         self.unk3 = 0
-        self.unk4 = 0
+        self.starting_point_count = 0
         self.unk5 = 0
         self.unk6 = 0
 
@@ -1072,7 +1072,7 @@ class BOL(object):
         bol.unk2 = read_uint8(f)
         bol.unk3 = read_uint8(f)
         bol.shadow_color = ColorRGB.from_file(f)
-        bol.unk4 = read_uint8(f)
+        bol.starting_point_count = read_uint8(f)
         bol.unk5 = read_uint8(f)
 
         sectioncounts[LIGHTPARAM] = read_uint8(f)
@@ -1117,6 +1117,7 @@ class BOL(object):
 
         f.seek(sectionoffsets[KARTPOINT])
         bol.kartpoints = KartStartPoints.from_file(f, (sectionoffsets[AREA] - sectionoffsets[KARTPOINT])//0x28)
+        assert len(bol.kartpoints.positions) == bol.starting_point_count
 
         f.seek(sectionoffsets[AREA])
         bol.areas = Areas.from_file(f, sectioncounts[AREA])
@@ -1161,7 +1162,7 @@ class BOL(object):
                 self.fog_startz, self.fog_endz,
                 self.unk1, self.unk2, self.unk3))
         self.shadow_color.write(f)
-        f.write(pack(">BB", self.unk4, self.unk5))
+        f.write(pack(">BB", len(self.kartpoints.positions), self.unk5))
         f.write(pack(">BB", len(self.lightparams), len(self.mgentries)))
         f.write(pack(">B", self.unk6))
 

--- a/widgets/data_editor.py
+++ b/widgets/data_editor.py
@@ -645,8 +645,6 @@ class BOLEdit(DataEditor):
                                            MIN_UNSIGNED_BYTE, MAX_UNSIGNED_BYTE)
         self.shadow_color = self.add_multiple_integer_input("Shadow Color", "shadow_color", ["r", "g", "b"],
                                                             MIN_UNSIGNED_BYTE, MAX_UNSIGNED_BYTE)
-        self.unk4 = self.add_integer_input("Unknown 4", "unk4",
-                                           MIN_UNSIGNED_BYTE, MAX_UNSIGNED_BYTE)
         self.unk5 = self.add_integer_input("Unknown 5", "unk5",
                                            MIN_UNSIGNED_BYTE, MAX_UNSIGNED_BYTE)
         self.unk6 = self.add_integer_input("Unknown 6", "unk6",
@@ -676,7 +674,6 @@ class BOLEdit(DataEditor):
         self.unk1.setText(str(obj.unk1))
         self.unk2.setChecked(obj.unk2 != 0)
         self.unk3.setText(str(obj.unk3))
-        self.unk4.setText(str(obj.unk4))
         self.unk5.setText(str(obj.unk5))
         self.unk6.setText(str(obj.unk6))
         self.shadow_color[0].setText(str(obj.shadow_color.r))


### PR DESCRIPTION
Previously, the user would need to manually populate the field, which was still labeled as **Unknown 4**.