### PR TITLE
Renamed labels and variable names of previously unknown fields in the BOL header.

### DIFF
--- a/lib/libbol.py
+++ b/lib/libbol.py
@@ -979,12 +979,12 @@ class BOL(object):
         self.fog_color = ColorRGB(0x64, 0x64, 0x64)
         self.fog_startz = 8000.0
         self.fog_endz = 230000.0
-        self.unk1 = 0
-        self.unk2 = 0
-        self.unk3 = 0
+        self.lod_bias = 0
+        self.dummy_start_line = 0
+        self.snow_effects = 0
+        self.shadow_opacity = 0
         self.starting_point_count = 0
-        self.unk5 = 0
-        self.unk6 = 0
+        self.sky_follow = 0
 
         self.shadow_color = ColorRGB(0x00, 0x00, 0x00)
 
@@ -1068,16 +1068,21 @@ class BOL(object):
 
         bol.fog_startz = read_float(f)
         bol.fog_endz = read_float(f)
-        bol.unk1 = read_uint16(f)
-        bol.unk2 = read_uint8(f)
-        bol.unk3 = read_uint8(f)
+        bol.lod_bias = read_uint8(f)
+        bol.dummy_start_line = read_uint8(f)
+        assert bol.lod_bias in (0, 1)
+        assert bol.dummy_start_line in (0, 1)
+        bol.snow_effects = read_uint8(f)
+        bol.shadow_opacity = read_uint8(f)
         bol.shadow_color = ColorRGB.from_file(f)
         bol.starting_point_count = read_uint8(f)
-        bol.unk5 = read_uint8(f)
+        bol.sky_follow = read_uint8(f)
+        assert bol.sky_follow in (0, 1)
 
         sectioncounts[LIGHTPARAM] = read_uint8(f)
         sectioncounts[MINIGAME] = read_uint8(f)
-        bol.unk6 = read_uint8(f)
+        padding = read_uint8(f)
+        assert padding == 0
 
         filestart = read_uint32(f)
         print(hex(f.tell()), filestart)
@@ -1158,13 +1163,13 @@ class BOL(object):
 
         f.write(pack(">B", self.fog_type))
         self.fog_color.write(f)
-        f.write(pack(">ffHBB",
+        f.write(pack(">ffBBBB",
                 self.fog_startz, self.fog_endz,
-                self.unk1, self.unk2, self.unk3))
+                self.lod_bias, self.dummy_start_line, self.snow_effects, self.shadow_opacity))
         self.shadow_color.write(f)
-        f.write(pack(">BB", len(self.kartpoints.positions), self.unk5))
+        f.write(pack(">BB", len(self.kartpoints.positions), self.sky_follow))
         f.write(pack(">BB", len(self.lightparams), len(self.mgentries)))
-        f.write(pack(">B", self.unk6))
+        f.write(pack(">B", 0))  # padding
 
         f.write(b"\x00"*4) # Filestart 0
 

--- a/widgets/data_editor.py
+++ b/widgets/data_editor.py
@@ -637,18 +637,16 @@ class BOLEdit(DataEditor):
                                                  -inf, +inf)
         self.fog_endz = self.add_decimal_input("Fog Far Z", "fog_endz",
                                                -inf, +inf)
-        self.unk1 = self.add_integer_input("Unknown 1", "unk1",
-                                           MIN_UNSIGNED_SHORT, MAX_UNSIGNED_SHORT)
-        self.unk2 = self.add_checkbox("Sherbet Land Env. Effects", "unk2",
-                                           off_value=0, on_value=1)
-        self.unk3 = self.add_integer_input("Unknown 3", "unk3",
-                                           MIN_UNSIGNED_BYTE, MAX_UNSIGNED_BYTE)
+        self.lod_bias = self.add_checkbox("LOD Bias", "lod_bias", off_value=0, on_value=1)
+        self.dummy_start_line = self.add_checkbox("Dummy Start Line", "dummy_start_line",
+                                                  off_value=0, on_value=1)
+        self.snow_effects = self.add_checkbox("Sherbet Land Env. Effects", "snow_effects",
+                                              off_value=0, on_value=1)
+        self.shadow_opacity = self.add_integer_input("Shadow Opacity", "shadow_opacity",
+                                                     MIN_UNSIGNED_BYTE, MAX_UNSIGNED_BYTE)
         self.shadow_color = self.add_multiple_integer_input("Shadow Color", "shadow_color", ["r", "g", "b"],
                                                             MIN_UNSIGNED_BYTE, MAX_UNSIGNED_BYTE)
-        self.unk5 = self.add_integer_input("Unknown 5", "unk5",
-                                           MIN_UNSIGNED_BYTE, MAX_UNSIGNED_BYTE)
-        self.unk6 = self.add_integer_input("Unknown 6", "unk6",
-                                           MIN_UNSIGNED_BYTE, MAX_UNSIGNED_BYTE)
+        self.sky_follow = self.add_checkbox("Sky Follow", "sky_follow", off_value=0, on_value=1)
 
     def update_data(self):
         obj: BOL = self.bound_to
@@ -671,11 +669,11 @@ class BOLEdit(DataEditor):
         self.fog_color[2].setText(str(obj.fog_color.b))
         self.fog_startz.setText(str(obj.fog_startz))
         self.fog_endz.setText(str(obj.fog_endz))
-        self.unk1.setText(str(obj.unk1))
-        self.unk2.setChecked(obj.unk2 != 0)
-        self.unk3.setText(str(obj.unk3))
-        self.unk5.setText(str(obj.unk5))
-        self.unk6.setText(str(obj.unk6))
+        self.lod_bias.setChecked(obj.lod_bias != 0)
+        self.dummy_start_line.setChecked(obj.dummy_start_line != 0)
+        self.snow_effects.setChecked(obj.snow_effects != 0)
+        self.shadow_opacity.setText(str(obj.shadow_opacity))
+        self.sky_follow.setChecked(obj.sky_follow != 0)
         self.shadow_color[0].setText(str(obj.shadow_color.r))
         self.shadow_color[1].setText(str(obj.shadow_color.g))
         self.shadow_color[2].setText(str(obj.shadow_color.b))


### PR DESCRIPTION
- **Unknown 1**: Split into **LOD Bias** and **Dummy Start Line**.
- **Unknown 3**: Renamed to **Shadow Opacity**.
- **Unknown 5**: Renamed to **Sky Follow**.
- **Unknown 6**: Removed from UI; always `0x00` in all stock BOL files.

When **LOD Bias** is on, the game seems to generate mipmaps differently, resulting in a sharper image in some cases. Value is used from `CrsData::isTexLODBiasOn()`.

**Dummy Start Line**, although named, remains unknown. It is not clear what this flag implies. The name is borrowed from the function that retrieves the value from the BOL file: `CrsData::isDummyStartLineOn()`.

**Sky Follow**, which is only enabled in Sherbet Land and Ending, enables a different set of matrix operations on the skydome. The name is borrowed from the `CrsData::isSkyFollow()` function.