### PR TITLE
Revised **Add Objects** dialog.

### DIFF
--- a/lib/libbol.py
+++ b/lib/libbol.py
@@ -953,7 +953,7 @@ class MGEntry(object):
 
     @classmethod
     def new(cls):
-        return cls(0)
+        return cls()
 
     @classmethod
     def from_file(cls, f):

--- a/mkdd_editor.py
+++ b/mkdd_editor.py
@@ -1733,6 +1733,9 @@ class GenEditor(QMainWindow):
                 placeobject.end.y = y
                 placeobject.end.z = z
                 self.last_position_clicked = []
+                # For convenience, create a group if none exists yet.
+                if group == 0 and not self.level_file.checkpoints.groups:
+                    self.level_file.checkpoints.groups.append(libbol.CheckpointGroup.new())
                 self.level_file.checkpoints.groups[group].points.insert(position, placeobject)
                 self.level_view.do_redraw()
                 self.set_has_unsaved_changes(True)
@@ -1747,9 +1750,15 @@ class GenEditor(QMainWindow):
             placeobject.position.z = z
 
             if isinstance(object, libbol.EnemyPoint):
+                # For convenience, create a group if none exists yet.
+                if group == 0 and not self.level_file.enemypointgroups.groups:
+                    self.level_file.enemypointgroups.groups.append(libbol.EnemyPointGroup.new())
                 placeobject.group = group
                 self.level_file.enemypointgroups.groups[group].points.insert(position, placeobject)
             elif isinstance(object, libbol.RoutePoint):
+                # For convenience, create a group if none exists yet.
+                if group == 0 and not self.level_file.routes:
+                    self.level_file.routes.append(libbol.Route.new())
                 self.level_file.routes[group].points.insert(position, placeobject)
             elif isinstance(object, libbol.MapObject):
                 self.level_file.objects.objects.append(placeobject)

--- a/mkdd_editor.py
+++ b/mkdd_editor.py
@@ -1719,7 +1719,7 @@ class GenEditor(QMainWindow):
                 elif isinstance(obj, libbol.LightParam):
                     self.level_file.lightparams.append(obj)
                 elif isinstance(obj, libbol.MGEntry):
-                    self.level_file.lightparams.append(obj)
+                    self.level_file.mgentries.append(obj)
 
                 self.addobjectwindow_last_selected_category = self.add_object_window.category_menu.currentIndex()
                 self.object_to_be_added = None

--- a/mkdd_editor.py
+++ b/mkdd_editor.py
@@ -1029,14 +1029,17 @@ class GenEditor(QMainWindow):
 
         self.level_view.customContextMenuRequested.connect(self.mapview_showcontextmenu)
 
-        self.pik_control.button_add_object.pressed.connect(self.button_open_add_item_window)
+        self.pik_control.button_add_object.clicked.connect(
+            lambda _checked: self.button_open_add_item_window())
         #self.pik_control.button_move_object.pressed.connect(self.button_move_objects)
         self.level_view.move_points.connect(self.action_move_objects)
         self.level_view.height_update.connect(self.action_change_object_heights)
         self.level_view.create_waypoint.connect(self.action_add_object)
         self.level_view.create_waypoint_3d.connect(self.action_add_object_3d)
-        self.pik_control.button_ground_object.pressed.connect(self.action_ground_objects)
-        self.pik_control.button_remove_object.pressed.connect(self.action_delete_objects)
+        self.pik_control.button_ground_object.clicked.connect(
+            lambda _checked: self.action_ground_objects())
+        self.pik_control.button_remove_object.clicked.connect(
+            lambda _checked: self.action_delete_objects())
 
         delete_shortcut = QtWidgets.QShortcut(QtGui.QKeySequence(Qt.Key_Delete), self)
         delete_shortcut.activated.connect(self.action_delete_objects)
@@ -1154,7 +1157,8 @@ class GenEditor(QMainWindow):
             ))
             self.edit_spawn_window.rotation.setText(str(self.pikmin_gen_file.startdir))
             self.edit_spawn_window.closing.connect(self.action_close_edit_startpos_window)
-            self.edit_spawn_window.button_savetext.pressed.connect(self.action_save_startpos)
+            self.edit_spawn_window.button_savetext.clicked.connect(
+                lambda _checked: self.action_save_startpos())
             self.edit_spawn_window.show()
 
     def update_recent_files_list(self, filepath):
@@ -1666,7 +1670,8 @@ class GenEditor(QMainWindow):
     def button_open_add_item_window(self):
         if self.add_object_window is None:
             self.add_object_window = AddPikObjectWindow()
-            self.add_object_window.button_savetext.pressed.connect(self.button_add_item_window_save)
+            self.add_object_window.button_savetext.clicked.connect(
+                lambda _checked: self.button_add_item_window_save())
             self.add_object_window.closing.connect(self.button_add_item_window_close)
             print("hmmm")
             if self.addobjectwindow_last_selected is not None:
@@ -1682,7 +1687,8 @@ class GenEditor(QMainWindow):
     def shortcut_open_add_item_window(self):
         if self.add_object_window is None:
             self.add_object_window = AddPikObjectWindow()
-            self.add_object_window.button_savetext.pressed.connect(self.button_add_item_window_save)
+            self.add_object_window.button_savetext.clicked.connect(
+                lambda _checked: self.button_add_item_window_save())
             self.add_object_window.closing.connect(self.button_add_item_window_close)
             print("object")
             if self.addobjectwindow_last_selected is not None:

--- a/mkdd_editor.py
+++ b/mkdd_editor.py
@@ -113,7 +113,8 @@ class GenEditor(QMainWindow):
 
         self.current_coordinates = None
         self.editing_windows = {}
-        self.add_object_window = None
+        self.add_object_window = AddPikObjectWindow(self)
+        self.add_object_window.setWindowIcon(self.windowIcon())
         self.object_to_be_added = None
 
         self.history = EditorHistory(20)
@@ -122,8 +123,6 @@ class GenEditor(QMainWindow):
         self._window_title = ""
         self._user_made_change = False
         self._justupdatingselectedobject = False
-
-        self.addobjectwindow_last_selected = None
 
         self.loaded_archive = None
         self.loaded_archive_file = None
@@ -194,10 +193,6 @@ class GenEditor(QMainWindow):
 
         self.editing_windows = {}
 
-        if self.add_object_window is not None:
-            self.add_object_window.destroy()
-            self.add_object_window = None
-
         if self.edit_spawn_window is not None:
             self.edit_spawn_window.destroy()
             self.edit_spawn_window = None
@@ -208,9 +203,6 @@ class GenEditor(QMainWindow):
         #self.pik_control.button_move_object.setChecked(False)
         self._window_title = ""
         self._user_made_change = False
-
-        self.addobjectwindow_last_selected = None
-        self.addobjectwindow_last_selected_category = None
 
     def set_base_window_title(self, name):
         self._window_title = name
@@ -1668,81 +1660,44 @@ class GenEditor(QMainWindow):
         self.set_has_unsaved_changes(True)
 
     def button_open_add_item_window(self):
-        if self.add_object_window is None:
-            self.add_object_window = AddPikObjectWindow()
-            self.add_object_window.button_savetext.clicked.connect(
-                lambda _checked: self.button_add_item_window_save())
-            self.add_object_window.closing.connect(self.button_add_item_window_close)
-            print("hmmm")
-            if self.addobjectwindow_last_selected is not None:
-                self.add_object_window.category_menu.setCurrentIndex(self.addobjectwindow_last_selected_category)
-                self.add_object_window.template_menu.setCurrentIndex(self.addobjectwindow_last_selected)
-
-            self.add_object_window.show()
-
-        elif self.level_view.mousemode == mkdd_widgets.MOUSE_MODE_ADDWP:
+        accepted = self.add_object_window.exec_()
+        if accepted:
+            self.add_item_window_save()
+        else:
             self.level_view.set_mouse_mode(mkdd_widgets.MOUSE_MODE_NONE)
             self.pik_control.button_add_object.setChecked(False)
 
     def shortcut_open_add_item_window(self):
-        if self.add_object_window is None:
-            self.add_object_window = AddPikObjectWindow()
-            self.add_object_window.button_savetext.clicked.connect(
-                lambda _checked: self.button_add_item_window_save())
-            self.add_object_window.closing.connect(self.button_add_item_window_close)
-            print("object")
-            if self.addobjectwindow_last_selected is not None:
-                self.add_object_window.category_menu.setCurrentIndex(self.addobjectwindow_last_selected_category)
-                self.add_object_window.template_menu.setCurrentIndex(self.addobjectwindow_last_selected)
+        self.button_open_add_item_window()
 
+    def add_item_window_save(self):
+        self.object_to_be_added = self.add_object_window.get_content()
+        if self.object_to_be_added is None:
+            return
 
-            self.add_object_window.show()
+        obj = self.object_to_be_added[0]
 
-    @catch_exception
-    def button_add_item_window_save(self):
-        print("ohai")
-        if self.add_object_window is not None:
-            self.object_to_be_added = self.add_object_window.get_content()
-            if self.object_to_be_added is None:
-                return
+        if isinstance(obj, (libbol.EnemyPointGroup, libbol.CheckpointGroup, libbol.Route,
+                            libbol.LightParam, libbol.MGEntry)):
+            if isinstance(obj, libbol.EnemyPointGroup):
+                self.level_file.enemypointgroups.groups.append(obj)
+            elif isinstance(obj, libbol.CheckpointGroup):
+                self.level_file.checkpoints.groups.append(obj)
+            elif isinstance(obj, libbol.Route):
+                self.level_file.routes.append(obj)
+            elif isinstance(obj, libbol.LightParam):
+                self.level_file.lightparams.append(obj)
+            elif isinstance(obj, libbol.MGEntry):
+                self.level_file.mgentries.append(obj)
 
-            obj = self.object_to_be_added[0]
+            self.object_to_be_added = None
+            self.pik_control.button_add_object.setChecked(False)
+            self.level_view.set_mouse_mode(mkdd_widgets.MOUSE_MODE_NONE)
+            self.leveldatatreeview.set_objects(self.level_file)
 
-            if isinstance(obj, (libbol.EnemyPointGroup, libbol.CheckpointGroup, libbol.Route,
-                                                    libbol.LightParam, libbol.MGEntry)):
-                if isinstance(obj, libbol.EnemyPointGroup):
-                    self.level_file.enemypointgroups.groups.append(obj)
-                elif isinstance(obj, libbol.CheckpointGroup):
-                    self.level_file.checkpoints.groups.append(obj)
-                elif isinstance(obj, libbol.Route):
-                    self.level_file.routes.append(obj)
-                elif isinstance(obj, libbol.LightParam):
-                    self.level_file.lightparams.append(obj)
-                elif isinstance(obj, libbol.MGEntry):
-                    self.level_file.mgentries.append(obj)
-
-                self.addobjectwindow_last_selected_category = self.add_object_window.category_menu.currentIndex()
-                self.object_to_be_added = None
-                self.add_object_window.destroy()
-                self.add_object_window = None
-                self.leveldatatreeview.set_objects(self.level_file)
-
-            elif self.object_to_be_added is not None:
-                self.addobjectwindow_last_selected_category = self.add_object_window.category_menu.currentIndex()
-                self.pik_control.button_add_object.setChecked(True)
-                #self.pik_control.button_move_object.setChecked(False)
-                self.level_view.set_mouse_mode(mkdd_widgets.MOUSE_MODE_ADDWP)
-                self.add_object_window.destroy()
-                self.add_object_window = None
-                #self.pikmin_gen_view.setContextMenuPolicy(Qt.DefaultContextMenu)
-
-    @catch_exception
-    def button_add_item_window_close(self):
-        # self.add_object_window.destroy()
-        print("Hmmm")
-        self.add_object_window = None
-        self.pik_control.button_add_object.setChecked(False)
-        self.level_view.set_mouse_mode(mkdd_widgets.MOUSE_MODE_NONE)
+        elif self.object_to_be_added is not None:
+            self.pik_control.button_add_object.setChecked(True)
+            self.level_view.set_mouse_mode(mkdd_widgets.MOUSE_MODE_ADDWP)
 
     @catch_exception
     def action_add_object(self, x, z):
@@ -1875,8 +1830,6 @@ class GenEditor(QMainWindow):
             self.level_view.set_mouse_mode(mkdd_widgets.MOUSE_MODE_NONE)
             self.pik_control.button_add_object.setChecked(False)
             #self.pik_control.button_move_object.setChecked(False)
-            if self.add_object_window is not None:
-                self.add_object_window.close()
 
         if event.key() == Qt.Key_Shift:
             self.level_view.shift_is_pressed = True

--- a/mkdd_widgets.py
+++ b/mkdd_widgets.py
@@ -550,6 +550,9 @@ class BolMapViewer(QtWidgets.QOpenGLWidget):
         else:
             self.setContextMenuPolicy(Qt.DefaultContextMenu)
 
+        cursor_shape = QtCore.Qt.ArrowCursor if mode == MOUSE_MODE_NONE else QtCore.Qt.CrossCursor
+        self.setCursor(cursor_shape)
+
     @property
     def zoom_factor(self):
         return self._zoom_factor/10.0

--- a/widgets/data_editor.py
+++ b/widgets/data_editor.py
@@ -61,6 +61,7 @@ class DataEditor(QWidget):
         self.bound_to = bound_to
         self.vbox = QVBoxLayout(self)
         self.vbox.setContentsMargins(0, 0, 0, 0)
+        self.vbox.setSpacing(3)
 
         self.setup_widgets()
 
@@ -85,6 +86,7 @@ class DataEditor(QWidget):
 
     def create_labeled_widget(self, parent, text, widget):
         layout = QHBoxLayout()
+        layout.setSpacing(5)
         label = self.create_label(text)
         label.setText(text)
         layout.addWidget(label)
@@ -93,6 +95,7 @@ class DataEditor(QWidget):
 
     def create_labeled_widgets(self, parent, text, widgetlist):
         layout = QHBoxLayout()
+        layout.setSpacing(5)
         label = self.create_label(text)
         label.setText(text)
         layout.addWidget(label)

--- a/widgets/data_editor.py
+++ b/widgets/data_editor.py
@@ -62,8 +62,6 @@ class DataEditor(QWidget):
         self.vbox = QVBoxLayout(self)
         self.vbox.setContentsMargins(0, 0, 0, 0)
 
-        self.description = self.add_label("Object")
-
         self.setup_widgets()
 
     def catch_text_update(self):

--- a/widgets/editor_widgets.py
+++ b/widgets/editor_widgets.py
@@ -225,13 +225,9 @@ class AddPikObjectWindow(QDialog):
         font.setFixedPitch(True)
         font.setPointSize(10)
 
-        self.dummywidget = QWidget(self)
-        self.dummywidget.setMaximumSize(0,0)
-
 
         self.verticalLayout = QVBoxLayout(self)
         self.verticalLayout.setAlignment(Qt.AlignTop)
-        self.verticalLayout.addWidget(self.dummywidget)
 
 
 

--- a/widgets/editor_widgets.py
+++ b/widgets/editor_widgets.py
@@ -274,6 +274,10 @@ class AddPikObjectWindow(QDialog):
 
         self.editor_widget = None
         self.editor_layout = QScrollArea()#QVBoxLayout(self.centralwidget)
+        palette = self.editor_layout.palette()
+        palette.setBrush(self.editor_layout.backgroundRole(), palette.dark())
+        self.editor_layout.setPalette(palette)
+        self.editor_layout.setWidgetResizable(True)
         self.verticalLayout.addWidget(self.editor_layout)
         #self.textbox_xml = QTextEdit(self.centralwidget)
         self.button_savetext = QPushButton(self)

--- a/widgets/editor_widgets.py
+++ b/widgets/editor_widgets.py
@@ -280,14 +280,16 @@ class AddPikObjectWindow(QDialog):
         self.editor_layout.setWidgetResizable(True)
         self.verticalLayout.addWidget(self.editor_layout)
         #self.textbox_xml = QTextEdit(self.centralwidget)
+        button_area_layout = QHBoxLayout()
         self.button_savetext = QPushButton(self)
         self.button_savetext.setText("Add Object")
         self.button_savetext.setToolTip("Hotkey: Ctrl+S")
-        self.button_savetext.setMaximumWidth(400)
         self.button_savetext.setDisabled(True)
         self.button_savetext.clicked.connect(self.accept)
+        button_area_layout.addStretch()
+        button_area_layout.addWidget(self.button_savetext)
 
-        self.verticalLayout.addWidget(self.button_savetext)
+        self.verticalLayout.addLayout(button_area_layout)
         self.setWindowTitle(self.window_name)
         self.created_object = None
         #QtWidgets.QShortcut(Qt.CTRL + Qt.Key_S, self).activated.connect(self.emit_add_object)

--- a/widgets/editor_widgets.py
+++ b/widgets/editor_widgets.py
@@ -204,13 +204,7 @@ class ErrorAnalyzer(QMdiSubWindow):
                                 break
 
 
-class AddPikObjectWindow(QMdiSubWindow):
-    triggered = pyqtSignal(object)
-    closing = pyqtSignal()
-
-    def closeEvent(self, event):
-        self.closing.emit()
-        super().closeEvent(event)
+class AddPikObjectWindow(QDialog):
 
     @catch_exception
     def __init__(self, *args, **kwargs):
@@ -223,8 +217,6 @@ class AddPikObjectWindow(QMdiSubWindow):
         self.resize(900, 500)
         self.setMinimumSize(QSize(300, 300))
 
-        self.centralwidget = QWidget(self)
-        self.setWidget(self.centralwidget)
         self.entity = None
 
         font = QFont()
@@ -237,7 +229,7 @@ class AddPikObjectWindow(QMdiSubWindow):
         self.dummywidget.setMaximumSize(0,0)
 
 
-        self.verticalLayout = QVBoxLayout(self.centralwidget)
+        self.verticalLayout = QVBoxLayout(self)
         self.verticalLayout.setAlignment(Qt.AlignTop)
         self.verticalLayout.addWidget(self.dummywidget)
 
@@ -251,14 +243,14 @@ class AddPikObjectWindow(QMdiSubWindow):
         self.hbox2 = QHBoxLayout()
 
 
-        self.label1 = QLabel(self.centralwidget)
-        self.label2 = QLabel(self.centralwidget)
-        self.label3 = QLabel(self.centralwidget)
+        self.label1 = QLabel(self)
+        self.label2 = QLabel(self)
+        self.label3 = QLabel(self)
         self.label1.setText("Group")
         self.label2.setText("Position in Group")
         self.label3.setText("(-1 means end of Group)")
-        self.group_edit = QLineEdit(self.centralwidget)
-        self.position_edit = QLineEdit(self.centralwidget)
+        self.group_edit = QLineEdit(self)
+        self.position_edit = QLineEdit(self)
 
         self.group_edit.setValidator(QtGui.QIntValidator(0, 2**31-1))
         self.position_edit.setValidator(QtGui.QIntValidator(-1, 2**31-1))
@@ -283,11 +275,12 @@ class AddPikObjectWindow(QMdiSubWindow):
         self.editor_layout = QScrollArea()#QVBoxLayout(self.centralwidget)
         self.verticalLayout.addWidget(self.editor_layout)
         #self.textbox_xml = QTextEdit(self.centralwidget)
-        self.button_savetext = QPushButton(self.centralwidget)
+        self.button_savetext = QPushButton(self)
         self.button_savetext.setText("Add Object")
         self.button_savetext.setToolTip("Hotkey: Ctrl+S")
         self.button_savetext.setMaximumWidth(400)
         self.button_savetext.setDisabled(True)
+        self.button_savetext.clicked.connect(self.accept)
 
         self.verticalLayout.addWidget(self.button_savetext)
         self.setWindowTitle(self.window_name)

--- a/widgets/editor_widgets.py
+++ b/widgets/editor_widgets.py
@@ -214,7 +214,9 @@ class AddPikObjectWindow(QDialog):
         else:
             self.window_name = "Add Object"
 
-        self.resize(900, 500)
+        width = self.fontMetrics().averageCharWidth() * 80
+        height = self.fontMetrics().height() * 42
+        self.resize(width, height)
         self.setMinimumSize(QSize(300, 300))
 
         self.entity = None

--- a/widgets/editor_widgets.py
+++ b/widgets/editor_widgets.py
@@ -265,8 +265,11 @@ class AddPikObjectWindow(QDialog):
         self.hbox2.addWidget(self.position_edit)
         self.hbox2.addWidget(self.label3)
 
-        self.group_edit.setDisabled(True)
-        self.position_edit.setDisabled(True)
+        self.label1.setVisible(False)
+        self.label2.setVisible(False)
+        self.label3.setVisible(False)
+        self.group_edit.setVisible(False)
+        self.position_edit.setVisible(False)
 
 
         self.editor_widget = None
@@ -353,13 +356,13 @@ class AddPikObjectWindow(QDialog):
             self.created_object = objecttype.new()
 
             if isinstance(self.created_object, (libbol.Checkpoint, libbol.EnemyPoint, libbol.RoutePoint)):
-                self.group_edit.setDisabled(False)
-                self.position_edit.setDisabled(False)
+                self.group_edit.setVisible(True)
+                self.position_edit.setVisible(True)
                 self.group_edit.setText("0")
                 self.position_edit.setText("-1")
             else:
-                self.group_edit.setDisabled(True)
-                self.position_edit.setDisabled(True)
+                self.group_edit.setVisible(False)
+                self.position_edit.setVisible(False)
                 self.group_edit.clear()
                 self.position_edit.clear()
 
@@ -375,8 +378,12 @@ class AddPikObjectWindow(QDialog):
             del self.created_object
             self.created_object = None
             self.button_savetext.setDisabled(True)
-            self.position_edit.setDisabled(True)
-            self.group_edit.setDisabled(True)
+            self.position_edit.setVisible(False)
+            self.group_edit.setVisible(False)
+
+        self.label1.setVisible(self.position_edit.isVisible())
+        self.label2.setVisible(self.position_edit.isVisible())
+        self.label3.setVisible(self.position_edit.isVisible())
 
 class SpawnpointEditor(QMdiSubWindow):
     triggered = pyqtSignal(object)

--- a/widgets/editor_widgets.py
+++ b/widgets/editor_widgets.py
@@ -369,6 +369,9 @@ class AddPikObjectWindow(QDialog):
             data_editor = choose_data_editor(self.created_object)
             if data_editor is not None:
                 self.editor_widget = data_editor(self, self.created_object)
+                self.editor_widget.layout().addStretch()
+                margin = self.fontMetrics().averageCharWidth()
+                self.editor_widget.setContentsMargins(margin, margin, margin, margin)
                 self.editor_layout.setWidget(self.editor_widget)
                 self.editor_widget.update_data()
 

--- a/widgets/editor_widgets.py
+++ b/widgets/editor_widgets.py
@@ -342,8 +342,27 @@ class AddPikObjectWindow(QDialog):
             "Minigame Param": libbol.MGEntry
         }
 
-        for item in sorted(self.objecttypes.keys()):
-            self.category_menu.addItem(item)
+        self.category_menu.addItem("Enemy Path")
+        self.category_menu.addItem("Enemy Point")
+        self.category_menu.insertSeparator(self.category_menu.count())
+        self.category_menu.addItem("Checkpoint Group")
+        self.category_menu.addItem("Checkpoint")
+        self.category_menu.insertSeparator(self.category_menu.count())
+        self.category_menu.addItem("Route")
+        self.category_menu.addItem("Route Point")
+        self.category_menu.insertSeparator(self.category_menu.count())
+        self.category_menu.addItem("Object")
+        self.category_menu.addItem("Kart Start Point")
+        self.category_menu.addItem("Area")
+        self.category_menu.addItem("Camera")
+        self.category_menu.addItem("Respawn Point")
+        self.category_menu.insertSeparator(self.category_menu.count())
+        self.category_menu.addItem("Light Param")
+        self.category_menu.addItem("Minigame Param")
+
+        for i in range(1, self.category_menu.count()):
+            text = self.category_menu.itemText(i)
+            assert not text or text in self.objecttypes
 
         self.category_menu.currentIndexChanged.connect(self.change_category)
 


### PR DESCRIPTION
The **Add Objects** window has been converted into a modal dialog. Only one of these dialogs is now ever created, which helps retaining the user's previous selection. Interaction with the modal dialog is now more robust, as it limits the user interaction while the dialog is visible.

A number of cosmetic changes have been applied to the dialog too:
- Types in combo box are now sorted with a logical order, rather than an asciibetical order.
- Paddings, margins, and unnecessary widgets/labels have been reduced or removed.
- Scrollable area is set to adjust to content.
- Scrollable area shows a dark, stylish background.
- The **Group** and **Position in Group** fields are now visible _only_ when relevant for the currently selected object type. (Previously, the field would be grayed out instead, while still occupying vertical space and distracting the user.)

In the viewport, a cross cursor shape (+) is now used while in insertion mode. This lets the user distinguish when a new object would be inserted, or when a marquee selection would be drawn.

Bonus: An issue where minigame params could never be added has been fixed too.