### PR TITLE
Revised camera type.

### DIFF
--- a/lib/libbol.py
+++ b/lib/libbol.py
@@ -824,7 +824,13 @@ class Camera(object):
 
         self.unkbyte = 0
         self.camtype = 0
-        self.startzoom = 0
+
+        class FOV:
+            def __ini__(self):
+                self.start = 0
+                self.end = 0
+
+        self.fov = FOV()
         self.camduration = 0
         self.startcamera = 0
 
@@ -836,7 +842,6 @@ class Camera(object):
         self.shimmer = Shimmer()
         self.route = -1
         self.routespeed = 0
-        self.endzoom = 0
         self.nextcam = -1
         self.name = "null"
 
@@ -859,14 +864,14 @@ class Camera(object):
         cam.position3 = Vector3(*unpack(">fff", f.read(12)))
         cam.unkbyte = read_uint8(f)
         cam.camtype = read_uint8(f)
-        cam.startzoom = read_uint16(f)
+        cam.fov.start = read_uint16(f)
         cam.camduration = read_uint16(f)
         cam.startcamera = read_uint16(f)
         cam.shimmer.z0 = read_uint16(f)
         cam.shimmer.z1 = read_uint16(f)
         cam.route = read_int16(f)
         cam.routespeed = read_uint16(f)
-        cam.endzoom = read_uint16(f)
+        cam.fov.end = read_uint16(f)
         cam.nextcam = read_int16(f)
         cam.name = str(f.read(4), encoding="ascii")
 
@@ -877,10 +882,10 @@ class Camera(object):
         self.rotation.write(f)
         f.write(pack(">fff", self.position2.x, self.position2.y, self.position2.z))
         f.write(pack(">fff", self.position3.x, self.position3.y, self.position3.z))
-        f.write(pack(">BBHHH", self.unkbyte, self.camtype, self.startzoom, self.camduration, self.startcamera))
+        f.write(pack(">BBHHH", self.unkbyte, self.camtype, self.fov.start, self.camduration, self.startcamera))
         f.write(pack(">HHhHHh",
                      self.shimmer.z0, self.shimmer.z1, self.route,
-                     self.routespeed, self.endzoom, self.nextcam))
+                     self.routespeed, self.fov.end, self.nextcam))
         assert len(self.name) == 4
         f.write(bytes(self.name, encoding="ascii"))
 

--- a/lib/libbol.py
+++ b/lib/libbol.py
@@ -827,8 +827,13 @@ class Camera(object):
         self.startzoom = 0
         self.camduration = 0
         self.startcamera = 0
-        self.unk2 = 0
-        self.unk3 = 0
+
+        class Shimmer:
+            def __init__(self):
+                self.z0 = 0
+                self.z1 = 0
+
+        self.shimmer = Shimmer()
         self.route = -1
         self.routespeed = 0
         self.endzoom = 0
@@ -857,8 +862,8 @@ class Camera(object):
         cam.startzoom = read_uint16(f)
         cam.camduration = read_uint16(f)
         cam.startcamera = read_uint16(f)
-        cam.unk2 = read_uint16(f)
-        cam.unk3 = read_uint16(f)
+        cam.shimmer.z0 = read_uint16(f)
+        cam.shimmer.z1 = read_uint16(f)
         cam.route = read_int16(f)
         cam.routespeed = read_uint16(f)
         cam.endzoom = read_uint16(f)
@@ -874,7 +879,7 @@ class Camera(object):
         f.write(pack(">fff", self.position3.x, self.position3.y, self.position3.z))
         f.write(pack(">BBHHH", self.unkbyte, self.camtype, self.startzoom, self.camduration, self.startcamera))
         f.write(pack(">HHhHHh",
-                     self.unk2, self.unk3, self.route,
+                     self.shimmer.z0, self.shimmer.z1, self.route,
                      self.routespeed, self.endzoom, self.nextcam))
         assert len(self.name) == 4
         f.write(bytes(self.name, encoding="ascii"))

--- a/lib/libbol.py
+++ b/lib/libbol.py
@@ -822,7 +822,6 @@ class Camera(object):
         self.position3 = Vector3(0.0, 0.0, 0.0)
         self.rotation = Rotation.default()
 
-        self.unkbyte = 0
         self.camtype = 0
 
         class FOV:
@@ -862,8 +861,7 @@ class Camera(object):
         cam.rotation = Rotation.from_file(f)
         cam.position2 = Vector3(*unpack(">fff", f.read(12)))
         cam.position3 = Vector3(*unpack(">fff", f.read(12)))
-        cam.unkbyte = read_uint8(f)
-        cam.camtype = read_uint8(f)
+        cam.camtype = read_uint16(f)
         cam.fov.start = read_uint16(f)
         cam.camduration = read_uint16(f)
         cam.startcamera = read_uint16(f)
@@ -882,7 +880,7 @@ class Camera(object):
         self.rotation.write(f)
         f.write(pack(">fff", self.position2.x, self.position2.y, self.position2.z))
         f.write(pack(">fff", self.position3.x, self.position3.y, self.position3.z))
-        f.write(pack(">BBHHH", self.unkbyte, self.camtype, self.fov.start, self.camduration, self.startcamera))
+        f.write(pack(">HHHH", self.camtype, self.fov.start, self.camduration, self.startcamera))
         f.write(pack(">HHhHHh",
                      self.shimmer.z0, self.shimmer.z1, self.route,
                      self.routespeed, self.fov.end, self.nextcam))

--- a/object_parameters/GeoShimmer.json
+++ b/object_parameters/GeoShimmer.json
@@ -1,10 +1,10 @@
 {
   "Object Parameters":
-          ["Unknown 1",
-            "Unknown 2",
-            "Unknown 3",
-            "Unknown 4",
-            "Unknown 5",
+          ["Texture-based Shimmering",
+            "Offset Z0",
+            "Offset Z1",
+            "Blend Rate Z0",
+            "Blend Rate Z1",
             "Unused",
             "Unused",
             "Unused"],

--- a/widgets/data_editor.py
+++ b/widgets/data_editor.py
@@ -897,10 +897,7 @@ class CameraEdit(DataEditor):
         self.camduration = self.add_integer_input("Camera Duration", "camduration",
                                                   MIN_UNSIGNED_SHORT, MAX_UNSIGNED_SHORT)
         self.startcamera = self.add_checkbox("Start Camera", "startcamera", off_value=0, on_value=1)
-        self.unk2 = self.add_integer_input("Unknown 2", "unk2",
-                                           MIN_UNSIGNED_SHORT, MAX_UNSIGNED_SHORT)
-        self.unk3 = self.add_integer_input("Unknown 3", "unk3",
-                                           MIN_UNSIGNED_SHORT, MAX_UNSIGNED_SHORT)
+        self.shimmer = self.add_multiple_integer_input("Shimmer", "shimmer", ["z0", "z1"], 0, 4095)
         self.route = self.add_integer_input("Route ID", "route",
                                             MIN_SIGNED_SHORT, MAX_SIGNED_SHORT)
         self.routespeed = self.add_integer_input("Route Speed", "routespeed",
@@ -932,8 +929,8 @@ class CameraEdit(DataEditor):
         self.startzoom.setText(str(obj.startzoom))
         self.camduration.setText(str(obj.camduration))
         self.startcamera.setChecked(obj.startcamera != 0)
-        self.unk2.setText(str(obj.unk2))
-        self.unk3.setText(str(obj.unk3))
+        self.shimmer[0].setText(str(obj.shimmer.z0))
+        self.shimmer[1].setText(str(obj.shimmer.z1))
         self.route.setText(str(obj.route))
         self.routespeed.setText(str(obj.routespeed))
         self.endzoom.setText(str(obj.endzoom))

--- a/widgets/data_editor.py
+++ b/widgets/data_editor.py
@@ -915,13 +915,13 @@ class CameraEdit(DataEditor):
         self.camduration = self.add_integer_input("Camera Duration", "camduration",
                                                   MIN_UNSIGNED_SHORT, MAX_UNSIGNED_SHORT)
         self.startcamera = self.add_checkbox("Start Camera", "startcamera", off_value=0, on_value=1)
+        self.nextcam = self.add_integer_input("Next Cam", "nextcam",
+                                              MIN_SIGNED_SHORT, MAX_SIGNED_SHORT)
         self.shimmer = self.add_multiple_integer_input("Shimmer", "shimmer", ["z0", "z1"], 0, 4095)
         self.route = self.add_integer_input("Route ID", "route",
                                             MIN_SIGNED_SHORT, MAX_SIGNED_SHORT)
         self.routespeed = self.add_integer_input("Route Speed", "routespeed",
                                                  MIN_UNSIGNED_SHORT, MAX_UNSIGNED_SHORT)
-        self.nextcam = self.add_integer_input("Next Cam", "nextcam",
-                                              MIN_SIGNED_SHORT, MAX_SIGNED_SHORT)
         self.name = self.add_text_input("Camera Name", "name", 4)
 
         self.camtype.currentIndexChanged.connect(lambda _index: self.catch_text_update())

--- a/widgets/data_editor.py
+++ b/widgets/data_editor.py
@@ -892,8 +892,8 @@ class CameraEdit(DataEditor):
                                               MIN_UNSIGNED_BYTE, MAX_UNSIGNED_BYTE)
         self.camtype = self.add_integer_input("Camera Type", "camtype",
                                               MIN_UNSIGNED_BYTE, MAX_UNSIGNED_BYTE)
-        self.startzoom = self.add_integer_input("Start FOV", "startzoom",
-                                                MIN_UNSIGNED_SHORT, MAX_UNSIGNED_SHORT)
+        self.fov = self.add_multiple_integer_input("Start/End FOV", "fov", ["start", "end"],
+                                                   MIN_UNSIGNED_SHORT, MAX_UNSIGNED_SHORT)
         self.camduration = self.add_integer_input("Camera Duration", "camduration",
                                                   MIN_UNSIGNED_SHORT, MAX_UNSIGNED_SHORT)
         self.startcamera = self.add_checkbox("Start Camera", "startcamera", off_value=0, on_value=1)
@@ -902,8 +902,6 @@ class CameraEdit(DataEditor):
                                             MIN_SIGNED_SHORT, MAX_SIGNED_SHORT)
         self.routespeed = self.add_integer_input("Route Speed", "routespeed",
                                                  MIN_UNSIGNED_SHORT, MAX_UNSIGNED_SHORT)
-        self.endzoom = self.add_integer_input("End FOV", "endzoom",
-                                              MIN_UNSIGNED_SHORT, MAX_UNSIGNED_SHORT)
         self.nextcam = self.add_integer_input("Next Cam", "nextcam",
                                               MIN_SIGNED_SHORT, MAX_SIGNED_SHORT)
         self.name = self.add_text_input("Camera Name", "name", 4)
@@ -926,14 +924,14 @@ class CameraEdit(DataEditor):
 
         self.unkbyte.setText(str(obj.unkbyte))
         self.camtype.setText(str(obj.camtype))
-        self.startzoom.setText(str(obj.startzoom))
+        self.fov[0].setText(str(obj.fov.start))
+        self.fov[1].setText(str(obj.fov.end))
         self.camduration.setText(str(obj.camduration))
         self.startcamera.setChecked(obj.startcamera != 0)
         self.shimmer[0].setText(str(obj.shimmer.z0))
         self.shimmer[1].setText(str(obj.shimmer.z1))
         self.route.setText(str(obj.route))
         self.routespeed.setText(str(obj.routespeed))
-        self.endzoom.setText(str(obj.endzoom))
         self.nextcam.setText(str(obj.nextcam))
         self.name.setText(obj.name)
 

--- a/widgets/data_editor.py
+++ b/widgets/data_editor.py
@@ -896,8 +896,7 @@ class CameraEdit(DataEditor):
                                                 MIN_UNSIGNED_SHORT, MAX_UNSIGNED_SHORT)
         self.camduration = self.add_integer_input("Camera Duration", "camduration",
                                                   MIN_UNSIGNED_SHORT, MAX_UNSIGNED_SHORT)
-        self.startcamera = self.add_integer_input("Start Camera", "startcamera",
-                                                  MIN_UNSIGNED_SHORT, MAX_UNSIGNED_SHORT)
+        self.startcamera = self.add_checkbox("Start Camera", "startcamera", off_value=0, on_value=1)
         self.unk2 = self.add_integer_input("Unknown 2", "unk2",
                                            MIN_UNSIGNED_SHORT, MAX_UNSIGNED_SHORT)
         self.unk3 = self.add_integer_input("Unknown 3", "unk3",
@@ -932,7 +931,7 @@ class CameraEdit(DataEditor):
         self.camtype.setText(str(obj.camtype))
         self.startzoom.setText(str(obj.startzoom))
         self.camduration.setText(str(obj.camduration))
-        self.startcamera.setText(str(obj.startcamera))
+        self.startcamera.setChecked(obj.startcamera != 0)
         self.unk2.setText(str(obj.unk2))
         self.unk3.setText(str(obj.unk3))
         self.route.setText(str(obj.route))

--- a/widgets/data_editor.py
+++ b/widgets/data_editor.py
@@ -200,6 +200,11 @@ class DataEditor(QWidget):
         for val in keyval_dict:
             combobox.addItem(val)
 
+        policy = combobox.sizePolicy()
+        policy.setHorizontalPolicy(QSizePolicy.Expanding)
+        combobox.setSizePolicy(policy)
+        combobox.setSizeAdjustPolicy(QComboBox.AdjustToMinimumContentsLengthWithIcon)
+
         layout = self.create_labeled_widget(self, text, combobox)
 
         def item_selected(item):
@@ -879,6 +884,22 @@ class AreaEdit(DataEditor):
         self.lightparam_index.setText(str(obj.lightparam_index))
 
 
+CAMERA_TYPES = OrderedDict()
+CAMERA_TYPES["000 - Fix | StartFix"] = 0x0000
+CAMERA_TYPES["001 - FixPath | StartOnlyPath"] = 0x0001
+CAMERA_TYPES["002 - FixChase"] = 0x0002
+CAMERA_TYPES["003 - FixSpl"] = 0x0003
+CAMERA_TYPES["004 - StartFixPath"] = 0x0004
+CAMERA_TYPES["005 - DemoPath | StartPath"] = 0x0005
+CAMERA_TYPES["006 - StartLookPath"] = 0x0006
+CAMERA_TYPES["007 - FixPala"] = 0x0007
+CAMERA_TYPES["008 - ?"] = 0x0008
+CAMERA_TYPES["100 - FixSearch"] = 0x0100
+CAMERA_TYPES["101 - ChasePath | StartChasePath"] = 0x0101
+CAMERA_TYPES["102 - Chase"] = 0x0102
+CAMERA_TYPES["103 - ChaseSpl"] = 0x0103
+
+
 class CameraEdit(DataEditor):
     def setup_widgets(self):
         self.position = self.add_multiple_decimal_input("Position", "position", ["x", "y", "z"],
@@ -888,10 +909,7 @@ class CameraEdit(DataEditor):
         self.position3 = self.add_multiple_decimal_input("Start Point", "position3", ["x", "y", "z"],
                                                         -inf, +inf)
         self.rotation = self.add_rotation_input()
-        self.unkbyte = self.add_integer_input("Unknown 1", "unkbyte",
-                                              MIN_UNSIGNED_BYTE, MAX_UNSIGNED_BYTE)
-        self.camtype = self.add_integer_input("Camera Type", "camtype",
-                                              MIN_UNSIGNED_BYTE, MAX_UNSIGNED_BYTE)
+        self.camtype = self.add_dropdown_input("Type", "camtype", CAMERA_TYPES)
         self.fov = self.add_multiple_integer_input("Start/End FOV", "fov", ["start", "end"],
                                                    MIN_UNSIGNED_SHORT, MAX_UNSIGNED_SHORT)
         self.camduration = self.add_integer_input("Camera Duration", "camduration",
@@ -905,6 +923,8 @@ class CameraEdit(DataEditor):
         self.nextcam = self.add_integer_input("Next Cam", "nextcam",
                                               MIN_SIGNED_SHORT, MAX_SIGNED_SHORT)
         self.name = self.add_text_input("Camera Name", "name", 4)
+
+        self.camtype.currentIndexChanged.connect(lambda _index: self.catch_text_update())
 
     def update_data(self):
         obj: Camera = self.bound_to
@@ -922,8 +942,7 @@ class CameraEdit(DataEditor):
 
         self.update_rotation(*self.rotation)
 
-        self.unkbyte.setText(str(obj.unkbyte))
-        self.camtype.setText(str(obj.camtype))
+        self.camtype.setCurrentIndex(list(CAMERA_TYPES.values()).index(obj.camtype))
         self.fov[0].setText(str(obj.fov.start))
         self.fov[1].setText(str(obj.fov.end))
         self.camduration.setText(str(obj.camduration))

--- a/widgets/data_editor.py
+++ b/widgets/data_editor.py
@@ -904,9 +904,9 @@ class CameraEdit(DataEditor):
     def setup_widgets(self):
         self.position = self.add_multiple_decimal_input("Position", "position", ["x", "y", "z"],
                                                         -inf, +inf)
-        self.position2 = self.add_multiple_decimal_input("End Point", "position2", ["x", "y", "z"],
-                                                        -inf, +inf)
         self.position3 = self.add_multiple_decimal_input("Start Point", "position3", ["x", "y", "z"],
+                                                        -inf, +inf)
+        self.position2 = self.add_multiple_decimal_input("End Point", "position2", ["x", "y", "z"],
                                                         -inf, +inf)
         self.rotation = self.add_rotation_input()
         self.camtype = self.add_dropdown_input("Type", "camtype", CAMERA_TYPES)

--- a/widgets/tree_view.py
+++ b/widgets/tree_view.py
@@ -180,7 +180,7 @@ class AreaEntry(NamedItem):
 
 class CameraEntry(NamedItem):
     def update_name(self):
-        self.setText(0, "Camera {0} (Type: {1})".format(self.index, self.bound_to.camtype))
+        self.setText(0, "Camera {0} (Type: {1:03X})".format(self.index, self.bound_to.camtype))
 
 
 class RespawnEntry(NamedItem):


### PR DESCRIPTION
- Use check box for the **Start Camera** flag.
- Use combo box for camera types.
- Name GeoShimmer's specific fields in JSON file.
- Add label for shimmer fields in the Camera type.
- Group **Start FOV** and **End FOV** in a single row in the Camera type's data editor. It saves vertical space, and makes it easy to locate both of them.
- Swap **Start Point** and **End Point** in the Camera type around, so that the start point is above the end point, which should be more natural.
- Move the **Next Cam** field underneath to the **Start Camera** flag.