### PR TITLE
Split the **Unknown** field in Enemy Points into **Drift Supplement** and **No Mushroom Zone**.

### DIFF
--- a/lib/libbol.py
+++ b/lib/libbol.py
@@ -258,7 +258,8 @@ class EnemyPoint(object):
                  group,
                  driftacuteness,
                  driftduration,
-                 unknown):
+                 driftsupplement,
+                 nomushroomzone):
         self.position = position
         self.driftdirection = driftdirection
         self.link = link
@@ -268,12 +269,14 @@ class EnemyPoint(object):
         self.group = group
         self.driftacuteness = driftacuteness
         self.driftduration = driftduration
-        self.unknown = unknown
+        self.driftsupplement = driftsupplement
+        self.nomushroomzone = nomushroomzone
 
         assert self.swerve in (-3, -2, -1, 0, 1, 2, 3)
         assert self.itemsonly in (0, 1)
         assert self.driftdirection in (0, 1, 2)
         assert 0 <= self.driftacuteness <= 180
+        assert self.nomushroomzone in (0, 1)
 
     @classmethod
     def new(cls):
@@ -287,7 +290,7 @@ class EnemyPoint(object):
         start = f.tell()
         args = [Vector3(*unpack(">fff", f.read(12)))]
         if not old_bol:
-            args.extend(unpack(">HhfbBBBBH", f.read(15)))
+            args.extend(unpack(">HhfbBBBBBB", f.read(15)))
             padding = f.read(5)  # padding
             assert padding == b"\x00" * 5
         else:
@@ -304,7 +307,7 @@ class EnemyPoint(object):
         start = f.tell()
         f.write(pack(">fff", self.position.x, self.position.y, self.position.z))
         f.write(pack(">Hhf", self.driftdirection, self.link, self.scale))
-        f.write(pack(">bBBBBH", self.swerve, self.itemsonly, self.group, self.driftacuteness, self.driftduration, self.unknown))
+        f.write(pack(">bBBBBBB", self.swerve, self.itemsonly, self.group, self.driftacuteness, self.driftduration, self.driftsupplement, self.nomushroomzone))
         f.write(b"\x00"*5)
         #assert f.tell() - start == self._size
 

--- a/mkdd_widgets.py
+++ b/mkdd_widgets.py
@@ -1084,9 +1084,12 @@ class BolMapViewer(QtWidgets.QOpenGLWidget):
                         if point.swerve:
                             glColor3f(0.1, 0.9, 0.2)
                             self.models.draw_cylinder(point.position, 400, 400)
-                        if point.unknown:
+                        if point.driftsupplement:
                             glColor3f(0.9, 0.0, 0.9)
                             self.models.draw_cylinder(point.position, 300, 300)
+                        if point.nomushroomzone:
+                            glColor3f(0.1, 0.8, 1.0)
+                            self.models.draw_cylinder(point.position, 900, 900)
 
                         point_index += 1
 

--- a/widgets/data_editor.py
+++ b/widgets/data_editor.py
@@ -500,16 +500,18 @@ class EnemyPointEdit(DataEditor):
                                                      MIN_UNSIGNED_BYTE, 180)
         self.driftduration = self.add_integer_input("Drift Duration", "driftduration",
                                                     MIN_UNSIGNED_BYTE, MAX_UNSIGNED_BYTE)
-        self.unknown = self.add_integer_input("Unknown", "unknown",
-                                              MIN_UNSIGNED_SHORT, MAX_UNSIGNED_SHORT)
+        self.driftsupplement = self.add_integer_input("Drift Supplement", "driftsupplement",
+                                                      MIN_UNSIGNED_BYTE, MAX_UNSIGNED_BYTE)
+        self.nomushroomzone = self.add_checkbox("No Mushroom Zone", "nomushroomzone",
+                                                off_value=0, on_value=1)
 
         for widget in self.position:
             widget.editingFinished.connect(self.catch_text_update)
-        for widget in (self.itemsonly, ):
+        for widget in (self.itemsonly, self.nomushroomzone):
             widget.stateChanged.connect(lambda _state: self.catch_text_update())
         for widget in (self.swerve, self.driftdirection):
             widget.currentIndexChanged.connect(lambda _index: self.catch_text_update())
-        for widget in (self.link, self.driftacuteness, self.driftduration, self.unknown):
+        for widget in (self.link, self.driftacuteness, self.driftduration, self.driftsupplement):
             widget.editingFinished.connect(self.catch_text_update)
 
     def update_data(self):
@@ -524,7 +526,8 @@ class EnemyPointEdit(DataEditor):
         self.group.setText(str(obj.group))
         self.driftacuteness.setText(str(obj.driftacuteness))
         self.driftduration.setText(str(obj.driftduration))
-        self.unknown.setText(str(obj.unknown))
+        self.driftsupplement.setText(str(obj.driftsupplement))
+        self.nomushroomzone.setChecked(bool(obj.nomushroomzone))
 
         if obj.swerve in SWERVE_IDS:
             name = SWERVE_IDS[obj.swerve]


### PR DESCRIPTION
The unsigned short is now treated as two different bytes.

The first byte is read and processed by `RivalBodyCtrl::initDrift()`, which uses it as a supplement for another value previously calculated.

The second byte is read and processed by `RivalItemCtrl::useItem_Kinoko_Normal()`, used to skip the whole function if the byte is not `0x00`.