### PR TITLE
Revised undo system.

### DIFF
--- a/lib/libbol.py
+++ b/lib/libbol.py
@@ -1,7 +1,6 @@
 import json
 from struct import unpack, pack
 from numpy import ndarray, array
-from binascii import hexlify
 from math import cos, sin
 from .vectors import Vector3
 from collections import OrderedDict
@@ -90,9 +89,6 @@ class Rotation(object):
 
         self.mtx[3][0] = self.mtx[3][1] = self.mtx[3][2] = 0.0
         self.mtx[3][3] = 1.0
-        #print(forward.x, -forward.z, forward.y)
-        #print(self.mtx)
-        #print([x for x in self.mtx])
 
     def rotate_around_x(self, degrees):
         mtx = ndarray(shape=(4,4), dtype=float, order="F", buffer=array([
@@ -366,7 +362,6 @@ class EnemyPointGroups(object):
 
         for i in range(count):
             enemypoint = EnemyPoint.from_file(f, old_bol)
-            print("Point", i, "in group", enemypoint.group, "links to", enemypoint.link)
             if enemypoint.group not in enemypointgroups._group_ids:
                 # start of group
                 curr_group = EnemyPointGroup()
@@ -503,7 +498,6 @@ class Checkpoint(object):
         start = Vector3(*unpack(">fff", f.read(12)))
         end = Vector3(*unpack(">fff", f.read(12)))
         unk1, unk2, unk3, unk4 = unpack(">BBBB", f.read(4))
-        #print(start, end)
         assert unk4 == 0
         assert unk2 == 0 or unk2 == 1
         assert unk3 == 0 or unk3 == 1
@@ -841,11 +835,6 @@ class Camera(object):
 
     @classmethod
     def from_file(cls, f):
-        start = f.tell()
-        hexd = f.read(4*3*4)
-        f.seek(start)
-        print(hexlify(hexd))
-
         position = Vector3(*unpack(">fff", f.read(12)))
 
         cam = cls(position)
@@ -1045,7 +1034,6 @@ class BOL(object):
     def from_file(cls, f):
         bol = cls()
         magic = f.read(4)
-        print(magic, type(magic))
         assert magic == b"0015" or magic == b"0012"
         old_bol = magic == b"0012"
 
@@ -1080,7 +1068,6 @@ class BOL(object):
         bol.unk6 = read_uint8(f)
 
         filestart = read_uint32(f)
-        print(hex(f.tell()), filestart)
         assert filestart == 0
 
         sectionoffsets = {}
@@ -1227,7 +1214,6 @@ class BOL(object):
         offsets.append(f.tell())
         for mgentry in self.mgentries:
             mgentry.write(f)
-        print(len(offsets))
         assert len(offsets) == 11
         f.seek(offset_start)
         for offset in offsets:

--- a/lib/libbol.py
+++ b/lib/libbol.py
@@ -1124,6 +1124,10 @@ class BOL(object):
 
         return bol
 
+    @classmethod
+    def from_bytes(cls, data: bytes) -> 'BOL':
+        return BOL.from_file(BytesIO(data))
+
     def write(self, f):
         f.write(b"0015")
         f.write(pack(">B", self.roll))
@@ -1218,6 +1222,11 @@ class BOL(object):
         f.seek(offset_start)
         for offset in offsets:
             f.write(pack(">I", offset))
+
+    def to_bytes(self) -> bytes:
+        f = BytesIO()
+        self.write(f)
+        return f.getvalue()
 
 
 with open("lib/mkddobjects.json", "r") as f:

--- a/widgets/tree_view.py
+++ b/widgets/tree_view.py
@@ -320,6 +320,25 @@ class LevelDataTreeView(QTreeWidget):
         self.mgentries.remove_children()
 
     def set_objects(self, boldata: BOL):
+        # Compute the location (based on indexes) of the currently selected item, if any.
+        selected_item_indexes = []
+        selected_items = self.selectedItems()
+        if selected_items:
+            item = selected_items[0]
+            while item is not None:
+                parent_item = item.parent()
+                if parent_item is not None:
+                    selected_item_indexes.insert(0, parent_item.indexOfChild(item))
+                else:
+                    selected_item_indexes.insert(0, self.indexOfTopLevelItem(item))
+                item = parent_item
+        selected_items = None
+
+        # Preserve the expansion state of the top-level items that can have nested groups.
+        enemyroutes_expansion_states = self._get_expansion_states(self.enemyroutes)
+        checkpointgroups_expansion_states = self._get_expansion_states(self.checkpointgroups)
+        routes_expansion_states = self._get_expansion_states(self.routes)
+
         self.reset()
 
         for group in boldata.enemypointgroups.groups:
@@ -363,6 +382,24 @@ class LevelDataTreeView(QTreeWidget):
         for mg in boldata.mgentries:
             item = MGEntry(self.mgentries, "MG", mg)
 
+        # Restore expansion states.
+        self._set_expansion_states(self.enemyroutes, enemyroutes_expansion_states)
+        self._set_expansion_states(self.checkpointgroups, checkpointgroups_expansion_states)
+        self._set_expansion_states(self.routes, routes_expansion_states)
+
+        # And restore previous selection.
+        if selected_item_indexes:
+            for item in self.selectedItems():
+                item.setSelected(False)
+            item = self.topLevelItem(selected_item_indexes.pop(0))
+            while selected_item_indexes:
+                index = selected_item_indexes.pop(0)
+                if index < item.childCount():
+                    item = item.child(index)
+                else:
+                    break
+            item.setSelected(True)
+
     def sort_objects(self):
         self.objects.sort()
         """items = []
@@ -373,3 +410,21 @@ class LevelDataTreeView(QTreeWidget):
 
         for item in items:
             self.objects.addChild(item)"""
+
+    def _get_expansion_states(self, parent_item: QTreeWidgetItem) -> 'tuple[bool]':
+        expansion_states = []
+        for i in range(parent_item.childCount()):
+            item = parent_item.child(i)
+            expansion_states.append(item.isExpanded())
+        return expansion_states
+
+    def _set_expansion_states(self, parent_item: QTreeWidgetItem, expansion_states: 'tuple[bool]'):
+        item_count = parent_item.childCount()
+        if item_count != len(expansion_states):
+            # If the number of children has changed, it is not possible to reliably restore the
+            # state without being very wrong in some cases.
+            return
+
+        for i in range(item_count):
+            item = parent_item.child(i)
+            item.setExpanded(expansion_states[i])

--- a/widgets/tree_view.py
+++ b/widgets/tree_view.py
@@ -214,6 +214,7 @@ class LevelDataTreeView(QTreeWidget):
         self.resize(200, self.height())
         self.setColumnCount(1)
         self.setHeaderLabel("Track Data Entries")
+        self.setHeaderHidden(True)
 
         self.bolheader = BolHeader()
         self.addTopLevelItem(self.bolheader)


### PR DESCRIPTION
`Ctrl+Z`, and `Ctrl+Shift+Z` (or `Ctrl+Y`) can be used to undo and redo the last action respectively.

The mechanism is based on the serialization of the `BOL` object, whose hash is used to determine when the document has changed, stashing the object in the undo stack when different.

`QtWidgets.QApplication` has been derived to globally monitor certain events in the `notify()` virtual method. When a key release event or a mouse button release event are detected, the current `BOL` object is serialized and compared with the hash of the previous object.