### PR TITLE
Revised area type.

### DIFF
--- a/lib/libbol.py
+++ b/lib/libbol.py
@@ -769,7 +769,7 @@ class Area(object):
         self.position = position
         self.scale = Vector3(1.0, 1.0, 1.0)
         self.rotation = Rotation.default()
-        self.check_flag = 0
+        self.shape = 0
         self.area_type = 0
         self.camera_index = -1
         self.unk1 = 0
@@ -792,7 +792,7 @@ class Area(object):
         area = cls(position)
         area.scale = Vector3(*unpack(">fff", f.read(12)))
         area.rotation = Rotation.from_file(f)
-        area.check_flag = read_uint8(f)
+        area.shape = read_uint8(f)
         area.area_type = read_uint8(f)
         area.camera_index = read_int16(f)
         area.unk1 = read_uint32(f)
@@ -802,6 +802,7 @@ class Area(object):
         area.shadow_id = read_int16(f)
         area.lightparam_index = read_int16(f)
 
+        assert area.shape in (0, 1)
         assert area.area_type in list(AREA_TYPES.keys())
 
         return area
@@ -810,7 +811,7 @@ class Area(object):
         f.write(pack(">fff", self.position.x, self.position.y, self.position.z))
         f.write(pack(">fff", self.scale.x, self.scale.y, self.scale.z))
         self.rotation.write(f)
-        f.write(pack(">BBh", self.check_flag, self.area_type, self.camera_index))
+        f.write(pack(">BBh", self.shape, self.area_type, self.camera_index))
         f.write(pack(">II", self.unk1, self.unk2))
         f.write(pack(">hhhh", self.unkfixedpoint, self.unkshort, self.shadow_id, self.lightparam_index))
 

--- a/lib/libbol.py
+++ b/lib/libbol.py
@@ -750,6 +750,20 @@ class KartStartPoints(object):
 
 # Section 7
 # Areas
+
+AREA_TYPES = {
+    0: "Shadow",
+    1: "Camera",
+    2: "Ceiling",
+    3: "No Dead Zone",
+    4: "Unknown 1",
+    5: "Unknown 2",
+    6: "Sound Effect",
+    7: "Lighting",
+}
+
+REVERSE_AREA_TYPES = dict(zip(AREA_TYPES.values(), AREA_TYPES.keys()))
+
 class Area(object):
     def __init__(self, position):
         self.position = position
@@ -785,6 +799,8 @@ class Area(object):
         area.unkshort = read_int16(f)
         area.shadow_id = read_int16(f)
         area.lightparam_index = read_int16(f)
+
+        assert area.area_type in list(AREA_TYPES.keys())
 
         return area
 

--- a/lib/libbol.py
+++ b/lib/libbol.py
@@ -779,6 +779,8 @@ class Area(object):
         self.shadow_id = 0
         self.lightparam_index = 0
 
+        self.widget = None
+
     @classmethod
     def new(cls):
         return cls(Vector3(0.0, 0.0, 0.0))
@@ -857,6 +859,8 @@ class Camera(object):
         self.nextcam = -1
         self.name = "null"
 
+        self.widget = None
+
     @classmethod
     def new(cls):
         return cls(Vector3(0.0, 0.0, 0.0))
@@ -906,6 +910,8 @@ class JugemPoint(object):
         self.unk1 = 0
         self.unk2 = 0
         self.unk3 = 0
+
+        self.widget = None
 
     @classmethod
     def new(cls):

--- a/lib/libbol.py
+++ b/lib/libbol.py
@@ -795,8 +795,15 @@ class Area(object):
         area.shape = read_uint8(f)
         area.area_type = read_uint8(f)
         area.camera_index = read_int16(f)
-        area.unk1 = read_uint32(f)
-        area.unk2 = read_uint32(f)
+
+        class Feather:
+            def __init__(self):
+                self.i0 = 0
+                self.i1 = 0
+
+        area.feather = Feather()
+        area.feather.i0 = read_uint32(f)
+        area.feather.i1 = read_uint32(f)
         area.unkfixedpoint = read_int16(f)
         area.unkshort = read_int16(f)
         area.shadow_id = read_int16(f)
@@ -812,7 +819,7 @@ class Area(object):
         f.write(pack(">fff", self.scale.x, self.scale.y, self.scale.z))
         self.rotation.write(f)
         f.write(pack(">BBh", self.shape, self.area_type, self.camera_index))
-        f.write(pack(">II", self.unk1, self.unk2))
+        f.write(pack(">II", self.feather.i0, self.feather.i1))
         f.write(pack(">hhhh", self.unkfixedpoint, self.unkshort, self.shadow_id, self.lightparam_index))
 
 

--- a/widgets/data_editor.py
+++ b/widgets/data_editor.py
@@ -10,7 +10,7 @@ from math import inf
 from lib.libbol import (EnemyPoint, EnemyPointGroup, CheckpointGroup, Checkpoint, Route, RoutePoint,
                         MapObject, KartStartPoint, Area, Camera, BOL, JugemPoint, MapObject,
                         LightParam, MGEntry, OBJECTNAMES, REVERSEOBJECTNAMES, MUSIC_IDS, REVERSE_MUSIC_IDS,
-                        SWERVE_IDS, REVERSE_SWERVE_IDS)
+                        SWERVE_IDS, REVERSE_SWERVE_IDS, REVERSE_AREA_TYPES)
 from lib.vectors import Vector3
 from lib.model_rendering import Minimap
 from PyQt5.QtCore import pyqtSignal
@@ -950,8 +950,7 @@ class AreaEdit(DataEditor):
         self.rotation = self.add_rotation_input()
         self.check_flag = self.add_integer_input("Check Flag", "check_flag",
                                                  MIN_UNSIGNED_BYTE, MAX_UNSIGNED_BYTE)
-        self.area_type = self.add_integer_input("Area Type", "area_type",
-                                                MIN_UNSIGNED_BYTE, MAX_UNSIGNED_BYTE)
+        self.area_type = self.add_dropdown_input("Area Type", "area_type", REVERSE_AREA_TYPES)
         self.camera_index = self.add_integer_input("Camera Index", "camera_index",
                                                    MIN_SIGNED_SHORT, MAX_SIGNED_SHORT)
         self.unk1 = self.add_integer_input("Unknown 1", "unk1",
@@ -980,7 +979,7 @@ class AreaEdit(DataEditor):
         self.update_rotation(*self.rotation)
 
         self.check_flag.setText(str(obj.check_flag))
-        self.area_type.setText(str(obj.area_type))
+        self.area_type.setCurrentIndex(obj.area_type)
         self.camera_index.setText(str(obj.camera_index))
         self.unk1.setText(str(obj.unk1))
         self.unk2.setText(str(obj.unk2))

--- a/widgets/data_editor.py
+++ b/widgets/data_editor.py
@@ -964,10 +964,8 @@ class AreaEdit(DataEditor):
         self.area_type = self.add_dropdown_input("Area Type", "area_type", REVERSE_AREA_TYPES)
         self.camera_index = self.add_integer_input("Camera Index", "camera_index",
                                                    MIN_SIGNED_SHORT, MAX_SIGNED_SHORT)
-        self.unk1 = self.add_integer_input("Unknown 1", "unk1",
-                                           MIN_UNSIGNED_INT, MAX_UNSIGNED_INT)
-        self.unk2 = self.add_integer_input("Unknown 2", "unk2",
-                                           MIN_UNSIGNED_INT, MAX_UNSIGNED_INT)
+        self.feather = self.add_multiple_integer_input("Feather", "feather", ["i0", "i1"],
+                                                       MIN_UNSIGNED_INT, MAX_SIGNED_INT)
         self.unkfixedpoint = self.add_integer_input("Unknown 3 Fixed Point", "unkfixedpoint",
                                                     MIN_SIGNED_SHORT, MAX_SIGNED_SHORT)
         self.unkshort = self.add_integer_input("Unknown 4", "unkshort",
@@ -994,8 +992,8 @@ class AreaEdit(DataEditor):
         self.shape.setCurrentIndex(obj.shape)
         self.area_type.setCurrentIndex(obj.area_type)
         self.camera_index.setText(str(obj.camera_index))
-        self.unk1.setText(str(obj.unk1))
-        self.unk2.setText(str(obj.unk2))
+        self.feather[0].setText(str(obj.feather.i0))
+        self.feather[1].setText(str(obj.feather.i1))
         self.unkfixedpoint.setText(str(obj.unkfixedpoint))
         self.unkshort.setText(str(obj.unkshort))
         self.shadow_id.setText(str(obj.shadow_id))

--- a/widgets/data_editor.py
+++ b/widgets/data_editor.py
@@ -947,6 +947,11 @@ class KartStartPointEdit(DataEditor):
         self.playerid.setText(str(obj.playerid))
         self.unknown.setText(str(obj.unknown))
 
+AREA_SHAPE = {
+    "Box": 0,
+    "Cylinder": 1,
+}
+
 
 class AreaEdit(DataEditor):
     def setup_widgets(self):
@@ -955,8 +960,7 @@ class AreaEdit(DataEditor):
         self.scale = self.add_multiple_decimal_input("Scale", "scale", ["x", "y", "z"],
                                                      -inf, +inf)
         self.rotation = self.add_rotation_input()
-        self.check_flag = self.add_integer_input("Check Flag", "check_flag",
-                                                 MIN_UNSIGNED_BYTE, MAX_UNSIGNED_BYTE)
+        self.shape = self.add_dropdown_input("Shape", "shape", AREA_SHAPE)
         self.area_type = self.add_dropdown_input("Area Type", "area_type", REVERSE_AREA_TYPES)
         self.camera_index = self.add_integer_input("Camera Index", "camera_index",
                                                    MIN_SIGNED_SHORT, MAX_SIGNED_SHORT)
@@ -987,7 +991,7 @@ class AreaEdit(DataEditor):
 
         self.update_rotation(*self.rotation)
 
-        self.check_flag.setText(str(obj.check_flag))
+        self.shape.setCurrentIndex(obj.shape)
         self.area_type.setCurrentIndex(obj.area_type)
         self.camera_index.setText(str(obj.camera_index))
         self.unk1.setText(str(obj.unk1))

--- a/widgets/data_editor.py
+++ b/widgets/data_editor.py
@@ -626,6 +626,8 @@ class EnemyPointEdit(DataEditor):
         for widget in (self.link, self.driftacuteness, self.driftduration, self.driftsupplement):
             widget.editingFinished.connect(self.catch_text_update)
 
+        self.link.editingFinished.connect(self.update_name)
+
     def update_data(self):
         obj: EnemyPoint = self.bound_to
         self.position[0].setText(str(round(obj.position.x, 3)))
@@ -647,6 +649,11 @@ class EnemyPointEdit(DataEditor):
             name = SWERVE_IDS[0]
         index = self.swerve.findText(name)
         self.swerve.setCurrentIndex(index)
+
+    def update_name(self):
+        if self.bound_to.widget is None:
+            return
+        self.bound_to.widget.update_name()
 
 
 class CheckpointGroupEdit(DataEditor):
@@ -966,6 +973,8 @@ class AreaEdit(DataEditor):
         self.lightparam_index = self.add_integer_input("LightParam Index", "lightparam_index",
                                                        MIN_SIGNED_SHORT, MAX_SIGNED_SHORT)
 
+        self.area_type.currentTextChanged.connect(self.update_name)
+
     def update_data(self):
         obj: Area = self.bound_to
         self.position[0].setText(str(round(obj.position.x, 3)))
@@ -987,6 +996,11 @@ class AreaEdit(DataEditor):
         self.unkshort.setText(str(obj.unkshort))
         self.shadow_id.setText(str(obj.shadow_id))
         self.lightparam_index.setText(str(obj.lightparam_index))
+
+    def update_name(self):
+        if self.bound_to.widget is None:
+            return
+        self.bound_to.widget.update_name()
 
 
 CAMERA_TYPES = OrderedDict()
@@ -1030,6 +1044,7 @@ class CameraEdit(DataEditor):
         self.name = self.add_text_input("Camera Name", "name", 4)
 
         self.camtype.currentIndexChanged.connect(lambda _index: self.catch_text_update())
+        self.camtype.currentTextChanged.connect(self.update_name)
 
     def update_data(self):
         obj: Camera = self.bound_to
@@ -1059,6 +1074,11 @@ class CameraEdit(DataEditor):
         self.nextcam.setText(str(obj.nextcam))
         self.name.setText(obj.name)
 
+    def update_name(self):
+        if self.bound_to.widget is None:
+            return
+        self.bound_to.widget.update_name()
+
 
 class RespawnPointEdit(DataEditor):
     def setup_widgets(self):
@@ -1074,6 +1094,8 @@ class RespawnPointEdit(DataEditor):
         self.unk3 = self.add_integer_input("Previous Checkpoint", "unk3",
                                            MIN_SIGNED_SHORT, MAX_SIGNED_SHORT)
 
+        self.respawn_id.editingFinished.connect(self.update_name)
+
     def update_data(self):
         obj: JugemPoint = self.bound_to
         self.position[0].setText(str(round(obj.position.x, 3)))
@@ -1085,6 +1107,10 @@ class RespawnPointEdit(DataEditor):
         self.unk2.setText(str(obj.unk2))
         self.unk3.setText(str(obj.unk3))
 
+    def update_name(self):
+        if self.bound_to.widget is None:
+            return
+        self.bound_to.widget.update_name()
 
 class LightParamEdit(DataEditor):
     def setup_widgets(self):

--- a/widgets/tree_view.py
+++ b/widgets/tree_view.py
@@ -91,6 +91,10 @@ class NamedItem(QTreeWidgetItem):
 
 
 class EnemyRoutePoint(NamedItem):
+    def __init__(self, parent, name, bound_to, index=None):
+        super().__init__(parent, name, bound_to, index)
+        bound_to.widget = self
+
     def update_name(self):
         group_item = self.parent()
         group = group_item.bound_to
@@ -174,16 +178,28 @@ class KartpointEntry(NamedItem):
 
 
 class AreaEntry(NamedItem):
+    def __init__(self, parent, name, bound_to, index=None):
+        super().__init__(parent, name, bound_to, index)
+        bound_to.widget = self
+
     def update_name(self):
         self.setText(0, AREA_TYPES[self.bound_to.area_type])
 
 
 class CameraEntry(NamedItem):
+    def __init__(self, parent, name, bound_to, index=None):
+        super().__init__(parent, name, bound_to, index)
+        bound_to.widget = self
+
     def update_name(self):
         self.setText(0, "Camera {0} (Type: {1:03X})".format(self.index, self.bound_to.camtype))
 
 
 class RespawnEntry(NamedItem):
+    def __init__(self, parent, name, bound_to, index=None):
+        super().__init__(parent, name, bound_to, index)
+        bound_to.widget = self
+
     def update_name(self):
         for i in range(self.parent().childCount()):
             if self == self.parent().child(i):

--- a/widgets/tree_view.py
+++ b/widgets/tree_view.py
@@ -1,5 +1,5 @@
 from PyQt5.QtWidgets import QTreeWidget, QTreeWidgetItem
-from lib.libbol import BOL, get_full_name
+from lib.libbol import BOL, get_full_name, AREA_TYPES
 from PyQt5.QtCore import Qt, pyqtSignal
 from PyQt5.QtWidgets import QAction, QMenu
 
@@ -175,7 +175,7 @@ class KartpointEntry(NamedItem):
 
 class AreaEntry(NamedItem):
     def update_name(self):
-        self.setText(0, "Area (Type: {0})".format(self.bound_to.area_type))
+        self.setText(0, AREA_TYPES[self.bound_to.area_type])
 
 
 class CameraEntry(NamedItem):


### PR DESCRIPTION
- Combo box for selecting area type (as opposed to numeric input).
- Area tree view items now show their area type name.
- Labels in tree view items are updated when their relevant properties are updated.
- **Shape** and **Feather** are now documented for areas, and use a combo box widget, or a dual numeric input, respectively.