### PR TITLE
Create deep copy of group objects that are cached in the **Add Objects** dialog.

### DIFF
--- a/mkdd_editor.py
+++ b/mkdd_editor.py
@@ -1736,6 +1736,8 @@ class GenEditor(QMainWindow):
 
         if isinstance(obj, (libbol.EnemyPointGroup, libbol.CheckpointGroup, libbol.Route,
                             libbol.LightParam, libbol.MGEntry)):
+            obj = deepcopy(obj)
+
             if isinstance(obj, libbol.EnemyPointGroup):
                 self.level_file.enemypointgroups.groups.append(obj)
             elif isinstance(obj, libbol.CheckpointGroup):


### PR DESCRIPTION
As part of PR #15, the **Add Objects** window was turned into a modal dialog whose lifespan matches the application's. The dialog is no longer recreated when re-opened, meaning that the cached instance of the currently selected object type is no longer recreated either [until the object type is changed].

However, the cached instance was being wrongly reused when a group-like object (enemy path, checkpoint group, or route) was created. The BOL document would end up with lists that contain more than one instance of the same Python object.

A deep copy of the cached instance is now created before appending it.