### PR TITLE
Enhance undo system.

### DIFF
--- a/lib/libbol.py
+++ b/lib/libbol.py
@@ -356,24 +356,24 @@ class EnemyPointGroup(object):
 class EnemyPointGroups(object):
     def __init__(self):
         self.groups = []
-        self._group_ids = {}
 
     @classmethod
     def from_file(cls, f, count, old_bol=False):
         enemypointgroups = cls()
+        group_ids = {}
         curr_group = None
 
         for i in range(count):
             enemypoint = EnemyPoint.from_file(f, old_bol)
-            if enemypoint.group not in enemypointgroups._group_ids:
+            if enemypoint.group not in group_ids:
                 # start of group
                 curr_group = EnemyPointGroup()
                 curr_group.id = enemypoint.group
-                enemypointgroups._group_ids[enemypoint.group] = curr_group
+                group_ids[enemypoint.group] = curr_group
                 curr_group.points.append(enemypoint)
                 enemypointgroups.groups.append(curr_group)
             else:
-                enemypointgroups._group_ids[enemypoint.group].points.append(enemypoint)
+                group_ids[enemypoint.group].points.append(enemypoint)
 
         return enemypointgroups
 


### PR DESCRIPTION
Follow-up to #19, where an undo system was put in place.

This undo system could only record actions that would produce a _different_ BOL document. Elements such as the minimap data (coordinates, and orientation), or _empty_ enemy paths are not part of the BOL format, and are not stored in the BOL document; modifying actions were therefore imperceptible by the undo system.

The undo system has now been revamped to specifically monitor changes in minimap data, and in enemy paths, ensuring that actions that produce a different minimap object, or a different enemy paths set are captured in the undo stack.