### PR TITLE
Clear marquee selection after effectively hitting the gizmo.

### DIFF
--- a/mkdd_widgets.py
+++ b/mkdd_widgets.py
@@ -689,6 +689,13 @@ class BolMapViewer(QtWidgets.QOpenGLWidget):
                 if do_gizmo and hit != 0xFF:
                     self.gizmo.run_callback(hit)
                     self.gizmo.was_hit_at_all = True
+
+                    # Clear the potential marquee selection, which may have been just created as a
+                    # result of a mouse move event that was processed slightly earlier than this
+                    # current paint event.
+                    self.selectionbox_start = self.selectionbox_end = None
+                    self.selectionbox_projected_origin = self.selectionbox_projected_coords = None
+
                 #if hit != 0xFF and do_:
 
             glClearColor(1.0, 1.0, 1.0, 1.0)


### PR DESCRIPTION
A stale marquee selection could be seen occasionally after interacting with the gizmo.

Demo of the issue:

![Stale marquee selection](https://user-images.githubusercontent.com/1853278/210139742-572a0729-e176-410a-bd37-b47d66ec670b.gif)

The problem seemingly had to do with `was_hit_at_all` being set too late. Mouse move events and paint events are not synchronized; they can occur at different times. If the mouse move event is processed *before* the paint event (where `was_hit_at_all` is set), then the marquee selection is effectively created.

Event order in which the problem was *not* manifested:

- **1. Press event:** Marquee selection is started, and a picking event is queued.
- **2. Paint event:** Queued picking event is processed. If it hits the gizmo, `was_hit_at_all` is set to `True`.
- **3. Move event:** Since `was_hit_at_all` is already set to `True`, the marquee selection is discarded, as it's one of the conditions to allow the creation of the marquee selection.

Event order in which the problem *was* manifested:

- **1. Press event:** Marquee selection is started; a picking event is queued.
- **3. Move event:** `was_hit_at_all` is still `False`, the marquee selection is effectively created.
- **2. Paint event:** Queued picking event is processed. Even if the gizmo is hit, the marquee selection is ready created, and will remain visible even when the gizmo is hit.