### PR TITLE
Address typo (`__ini__` vs `__init__`) in the `Camera` class.

### DIFF
--- a/lib/libbol.py
+++ b/lib/libbol.py
@@ -846,7 +846,7 @@ class Camera(object):
         self.camtype = 0
 
         class FOV:
-            def __ini__(self):
+            def __init__(self):
                 self.start = 0
                 self.end = 0
 


### PR DESCRIPTION
The following exception was raised when attempting to select the camera type in the **Add Objects** dialog:

```
Traceback (most recent call last):
  File "widgets/editor_widgets.py", line 444, in change_category
    self.editor_widget.update_data()
  File "widgets/data_editor.py", line 1068, in update_data
    self.fov[0].setText(str(obj.fov.start))
AttributeError: 'FOV' object has no attribute 'start'
```

It prevented the creation of new camera objects (unless loaded from file).