### PR TITLE
Copy & paste functionality.

### DIFF
--- a/lib/libbol.py
+++ b/lib/libbol.py
@@ -1068,6 +1068,30 @@ class BOL(object):
             assert respawn is not None
             yield respawn
 
+    def get_all_objects(self):
+        objects = []
+
+        for group in self.enemypointgroups.groups:
+            objects.append(group)
+            objects.extend(group.points)
+
+        for group in self.checkpoints.groups:
+            objects.append(group)
+            objects.extend(group.points)
+
+        for route in self.routes:
+            objects.append(route)
+            objects.extend(route.points)
+
+        objects.extend(self.objects.objects)
+        objects.extend(self.kartpoints.positions)
+        objects.extend(self.areas.areas)
+        objects.extend(self.cameras)
+        objects.extend(self.respawnpoints)
+        objects.extend(self.lightparams)
+        objects.extend(self.mgentries)
+
+        return objects
 
     @classmethod
     def from_file(cls, f):

--- a/lib/libbol.py
+++ b/lib/libbol.py
@@ -764,6 +764,13 @@ AREA_TYPES = {
 
 REVERSE_AREA_TYPES = dict(zip(AREA_TYPES.values(), AREA_TYPES.keys()))
 
+
+class Feather:
+    def __init__(self):
+        self.i0 = 0
+        self.i1 = 0
+
+
 class Area(object):
     def __init__(self, position):
         self.position = position
@@ -772,12 +779,6 @@ class Area(object):
         self.shape = 0
         self.area_type = 0
         self.camera_index = -1
-
-        class Feather:
-            def __init__(self):
-                self.i0 = 0
-                self.i1 = 0
-
         self.feather = Feather()
         self.unkfixedpoint = 0
         self.unkshort = 0
@@ -836,29 +837,29 @@ class Areas(object):
 
 # Section 8
 # Cameras
+
+class FOV:
+    def __init__(self):
+        self.start = 0
+        self.end = 0
+
+
+class Shimmer:
+    def __init__(self):
+        self.z0 = 0
+        self.z1 = 0
+
+
 class Camera(object):
     def __init__(self, position):
         self.position = position
         self.position2 = Vector3(0.0, 0.0, 0.0)
         self.position3 = Vector3(0.0, 0.0, 0.0)
         self.rotation = Rotation.default()
-
         self.camtype = 0
-
-        class FOV:
-            def __init__(self):
-                self.start = 0
-                self.end = 0
-
         self.fov = FOV()
         self.camduration = 0
         self.startcamera = 0
-
-        class Shimmer:
-            def __init__(self):
-                self.z0 = 0
-                self.z1 = 0
-
         self.shimmer = Shimmer()
         self.route = -1
         self.routespeed = 0

--- a/lib/object_models.py
+++ b/lib/object_models.py
@@ -92,12 +92,14 @@ class ObjectModels(object):
     def draw_arrow_head(self, frompos, topos):
         glPushMatrix()
         dir = topos-frompos
-        dir.normalize()
-
-        glMultMatrixf([dir.x, -dir.z, 0, 0,
-                       -dir.z, -dir.x, 0, 0,
-                       0, 0, 1, 0,
-                       topos.x, -topos.z, topos.y, 1])
+        if not dir.is_zero():
+            dir.normalize()
+            glMultMatrixf([dir.x, -dir.z, 0, 0,
+                           -dir.z, -dir.x, 0, 0,
+                           0, 0, 1, 0,
+                           topos.x, -topos.z, topos.y, 1])
+        else:
+            glTranslatef(topos.x, -topos.z, topos.y)
         self.arrow_head.render()
         glPopMatrix()
         #glBegin(GL_LINES)

--- a/mkdd_widgets.py
+++ b/mkdd_widgets.py
@@ -897,7 +897,6 @@ class BolMapViewer(QtWidgets.QOpenGLWidget):
                     self.selected = selected
                     self.selected_positions = selected_positions
                     self.selected_rotations = selected_rotations
-                    self.select_update.emit()
 
                 else:
                     for obj in selected:
@@ -911,7 +910,23 @@ class BolMapViewer(QtWidgets.QOpenGLWidget):
                         if rot not in self.selected_rotations:
                             self.selected_rotations.append(rot)
 
-                    self.select_update.emit()
+                # Store selection in a logical order that matches the order of the objects in their
+                # respective groups. This is relevant to ensure that potentially copied, route-like
+                # objects, where order matters, are pasted in the same order.
+                # Objects that are not part of the BOL document are kept at the end of the list in
+                # the same initial, arbitrary pick order.
+                selected = self.selected
+                self.selected = []
+                selected_set = set(selected)
+                for obj in self.level_file.get_all_objects():
+                    if obj in selected_set:
+                        self.selected.append(obj)
+                        selected_set.remove(obj)
+                for obj in selected:
+                    if obj in selected_set:
+                        self.selected.append(obj)
+
+                self.select_update.emit()
 
                 self.gizmo.move_to_average(self.selected_positions)
                 if len(selected) == 0:


### PR DESCRIPTION
All object types can be copied (or cut), and pasted.

In the base behavior, objects are appended to the last (or only) group. For enemy points, checkpoints, or route points, there will be an attempt to append the new objects to the group that contains the currently selected tree item.

Depends on #31, where `select_tree_item_bound_to()` was introduced.

---

Future work: Add action for pasting/inserting at the index of the currently selected tree item, as opposed to appending.