### PR TITLE
Edit typo when extracting "kd" field in .mtl file

### DIFF
--- a/lib/model_rendering.py
+++ b/lib/model_rendering.py
@@ -370,7 +370,7 @@ class TexturedModel(object):
                                     lasttex = None
 
                                 lastmat = " ".join(mtlargs[1:])
-                            elif mtlargs[0].lower() == "Kd":
+                            elif mtlargs[0].lower() == "kd":
                                 r, g, b = map(float, mtlargs[1:4])
                                 lastdiffuse = (r,g,b)
                             elif mtlargs[0].lower() == "map_kd":


### PR DESCRIPTION
.lower() compared to "Kd" will always be false - compare to "kd" instead. 