### PR TITLE
Side buttons for enemypoints

### DIFF
--- a/lib/libbol.py
+++ b/lib/libbol.py
@@ -352,6 +352,8 @@ class EnemyPointGroup(object):
         pos = self.points.index(point)
         self.points = self.points[:pos+1]
 
+    def get_index_of_point(self, point: EnemyPoint):
+        return self.points.index(point)
 
 class EnemyPointGroups(object):
     def __init__(self):
@@ -410,7 +412,10 @@ class EnemyPointGroups(object):
 
         return max_link+1
 
-
+    def add_group(self):
+        new_enemy_group = EnemyPointGroup()
+        new_enemy_group.id = self.new_group_id()
+        self.groups.append(new_enemy_group)
 # Enemy/Item Route Code End
 
 

--- a/widgets/more_buttons.py
+++ b/widgets/more_buttons.py
@@ -1,0 +1,33 @@
+from PyQt5.QtWidgets import QWidget, QVBoxLayout, QPushButton
+from lib.libbol import *
+from widgets.tree_view import BolHeader
+
+class MoreButtons(QWidget):
+    def __init__(self, parent):
+        super().__init__(parent)
+        self.vbox = QVBoxLayout(self)
+        self.vbox.setContentsMargins(0, 0, 0, 0)
+
+    def add_buttons(self, option = None):
+        self.clear_buttons()
+
+        if option is None or isinstance(option, BolHeader):
+            return
+
+        obj = option.bound_to
+        if isinstance(obj, EnemyPointGroups):
+            new_enemy_group = QPushButton(self)
+            new_enemy_group.setText("Add Enemy Path")
+            new_enemy_group.clicked.connect(
+                lambda: self.parent().parent.button_side_button_action("add_enemypath", obj) )
+            self.vbox.addWidget(new_enemy_group)
+        elif isinstance(obj, (EnemyPointGroup, EnemyPoint)):
+            new_enemy_point = QPushButton(self)
+            new_enemy_point.setText("Add Enemy Points")
+            new_enemy_point.clicked.connect(
+                lambda: self.parent().parent.button_side_button_action("add_enemypoints", obj) )
+            self.vbox.addWidget(new_enemy_point)
+
+    def clear_buttons(self):
+        for i in reversed(range(self.vbox.count())):
+            self.vbox.itemAt(i).widget().setParent(None)

--- a/widgets/side_widget.py
+++ b/widgets/side_widget.py
@@ -6,6 +6,7 @@ import PyQt5.QtCore as QtCore
 from PyQt5.QtCore import QSize, pyqtSignal, QPoint, QRect
 from PyQt5.QtCore import Qt
 from widgets.data_editor import choose_data_editor
+from widgets.more_buttons import MoreButtons
 
 class PikminSideWidget(QWidget):
     def __init__(self, *args, **kwargs):
@@ -58,6 +59,11 @@ class PikminSideWidget(QWidget):
         self.verticalLayout.addWidget(self.button_remove_object)
         self.verticalLayout.addWidget(self.button_ground_object)
         #self.verticalLayout.addWidget(self.button_move_object)
+
+        self.more_buttons = MoreButtons(parent)
+        self.more_buttons.add_buttons(None)
+        self.verticalLayout.addWidget(self.more_buttons)
+
         self.verticalLayout.addStretch(20)
 
         self.name_label = QLabel(parent)
@@ -174,4 +180,5 @@ class PikminSideWidget(QWidget):
 
         self.comment_label.setText(text)
 
-
+    def set_buttons(self, obj):
+        self.more_buttons.add_buttons(obj)

--- a/widgets/tree_view.py
+++ b/widgets/tree_view.py
@@ -4,13 +4,19 @@ from PyQt5.QtCore import Qt, pyqtSignal
 from PyQt5.QtWidgets import QAction, QMenu
 
 
-class BolHeader(QTreeWidgetItem):
+class BaseTreeWidgetItem(QTreeWidgetItem):
+
+    def get_index_in_parent(self):
+        return self.parent().indexOfChild(self)
+
+
+class BolHeader(BaseTreeWidgetItem):
     def __init__(self):
         super().__init__()
         self.setText(0, "Track Settings")
 
 
-class ObjectGroup(QTreeWidgetItem):
+class ObjectGroup(BaseTreeWidgetItem):
     def __init__(self, name, parent=None, bound_to=None):
         if parent is None:
             super().__init__()
@@ -78,7 +84,7 @@ class ObjectPointGroup(ObjectGroup):
 
 
 # Entries in groups or entries without groups
-class NamedItem(QTreeWidgetItem):
+class NamedItem(BaseTreeWidgetItem):
     def __init__(self, parent, name, bound_to, index=None):
         super().__init__(parent)
         self.setText(0, name)
@@ -417,6 +423,8 @@ class LevelDataTreeView(QTreeWidget):
                     break
             item.setSelected(True)
 
+        self.bound_to_group(boldata)
+
     def sort_objects(self):
         self.objects.sort()
         """items = []
@@ -445,3 +453,14 @@ class LevelDataTreeView(QTreeWidget):
         for i in range(item_count):
             item = parent_item.child(i)
             item.setExpanded(expansion_states[i])
+
+    def bound_to_group(self, levelfile):
+        self.enemyroutes.bound_to = levelfile.enemypointgroups
+        self.checkpointgroups.bound_to = levelfile.checkpoints
+        self.routes.bound_to = levelfile.routes
+        self.objects.bound_to = levelfile.objects
+        self.kartpoints.bound_to = levelfile.kartpoints
+        self.areas.bound_to = levelfile.areas
+        self.cameras.bound_to = levelfile.cameras
+        self.respawnpoints.bound_to = levelfile.respawnpoints
+        self.lightparams.bound_to = levelfile.lightparams


### PR DESCRIPTION
Start to add side buttons for the enemypoints as the beginning of an attempt to phase out the Add Object button. This change will allow users to more easily add groups and points without having to go through the menu. 
This functionality will slowly be expanded to cover all parts of .bol files. 