### PR TITLE
Check that file exists before loading it

### DIFF
--- a/mkdd_editor.py
+++ b/mkdd_editor.py
@@ -1451,9 +1451,11 @@ class GenEditor(QMainWindow):
                             else:
                                 self.clear_collision()
                         elif bmdfile is not None and self.editorconfig["addi_file_on_load"] == "BMD":
-                            self.load_optional_bmd(bmdfile)
+                            if os.path.isfile(bmdfile):
+                                self.load_optional_bmd(bmdfile)
                         elif collisionfile is not None and self.editorconfig["addi_file_on_load"] == "BCO":
-                            self.load_optional_bco(collisionfile)
+                            if os.path.isfile(collisionfile):
+                                self.load_optional_bco(collisionfile)
                         elif self.editorconfig["addi_file_on_load"] == "None":
                             self.clear_collision()
 


### PR DESCRIPTION
The current auto 3d model file loading assumes that a _bco / _bmd will be in the same directory as the .bol. This is not always true, so check that the file exists before trying to load it. 