### PR TITLE
New tooltips feature when hovering over input fields

### DIFF
--- a/object_parameters/GeoBombCar.json
+++ b/object_parameters/GeoBombCar.json
@@ -8,5 +8,15 @@
             "Unknown 6",
             "Unknown 7",
             "Unknown 8"],
-  "Assets": ["car_bomb1.bmd", "car_bomb1.btk", "car_bomb1shadow.bmd"]
+  "Assets": ["car_bomb1.bmd", "car_bomb1.btk", "car_bomb1shadow.bmd"],
+  "Tooltips": [
+    "Vehicle speed",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    ""
+  ]
 }

--- a/object_parameters/GeoBus.json
+++ b/object_parameters/GeoBus.json
@@ -8,5 +8,15 @@
             "Unknown 6",
             "Unknown 7",
             "Unknown 8"],
-  "Assets": ["car_bus1.bmd", "car_bus1.btk", "car_bus1.btp"]
+  "Assets": ["car_bus1.bmd", "car_bus1.btk", "car_bus1.btp"],
+  "Tooltips": [
+    "Vehicle speed",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    ""
+  ]
 }

--- a/object_parameters/GeoCannon.json
+++ b/object_parameters/GeoCannon.json
@@ -8,5 +8,15 @@
             "Unused",
             "Unused",
             "Unused"],
-  "Assets": ["cannon1.bca", "cannon1.bmd", "cannon1.brk"]
+  "Assets": ["cannon1.bca", "cannon1.bmd", "cannon1.brk"],
+  "Tooltips": [
+    "The Respawn ID that the cannon will shoot towards",
+    "",
+    "Sets model visibility. 0 = visible, 1 = invisible",
+    "",
+    "",
+    "",
+    "",
+    ""
+  ]
 }

--- a/object_parameters/GeoF_ItemBox.json
+++ b/object_parameters/GeoF_ItemBox.json
@@ -8,5 +8,15 @@
             "Unused",
             "Unused",
             "Unused"],
-  "Assets": []
+  "Assets": [],
+  "Tooltips": [
+    "How high off the ground the itembox will be. Itembox must be grounded and this set to 135",
+    "Whether itembox is single or double. 0 = both, 1 = single only, 3 = double only",
+    "",
+    "",
+    "",
+    "",
+    "",
+    ""
+  ]
 }

--- a/object_parameters/GeoItemBox.json
+++ b/object_parameters/GeoItemBox.json
@@ -8,5 +8,15 @@
             "Unused",
             "Unused",
             "Unused"],
-  "Assets": []
+  "Assets": [],
+  "Tooltips": [
+    "How high off the ground the itembox will be. Itembox must be grounded and this set to 135",
+    "Whether itembox is single or double. 0 = both, 1 = single only, 3 = double only",
+    "",
+    "",
+    "",
+    "",
+    "",
+    ""
+  ]
 }

--- a/object_parameters/GeoItemCar.json
+++ b/object_parameters/GeoItemCar.json
@@ -8,5 +8,15 @@
             "Unknown 6",
             "Unknown 7",
             "Unknown 8"],
-  "Assets": ["car_item1.bmd", "car_item1.btk"]
+  "Assets": ["car_item1.bmd", "car_item1.btk"],
+  "Tooltips": [
+    "Vehicle speed",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    ""
+  ]
 }

--- a/object_parameters/GeoKinoCar.json
+++ b/object_parameters/GeoKinoCar.json
@@ -8,5 +8,15 @@
             "Unknown 6",
             "Unknown 7",
             "Unknown 8"],
-  "Assets": ["car_kinoko1.bmd", "car_kinoko1.btk", "car_konoko1shadow.bmd"]
+  "Assets": ["car_kinoko1.bmd", "car_kinoko1.btk", "car_konoko1shadow.bmd"],
+  "Tooltips": [
+    "Vehicle speed",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    ""
+  ]
 }

--- a/object_parameters/GeoNormCar.json
+++ b/object_parameters/GeoNormCar.json
@@ -8,5 +8,15 @@
             "Unknown 6",
             "Unknown 7",
             "Unknown 8"],
-  "Assets": ["car_public1.bmd", "car_public1.btk", "car_public1.btp", "car_public1shadow.bmd"]
+  "Assets": ["car_public1.bmd", "car_public1.btk", "car_public1.btp", "car_public1shadow.bmd"],
+  "Tooltips": [
+    "Vehicle speed",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    ""
+  ]
 }

--- a/object_parameters/GeoPuller.json
+++ b/object_parameters/GeoPuller.json
@@ -8,6 +8,15 @@
             "Unused",
             "Unused",
             "Unused"],
-  "Assets": [""]
-}
+  "Assets": [""],
+  "Tooltips": [
+    "The strength it'll pull with on 50cc",
+    "The strength it'll pull with on 100cc",
+    "The strength it'll pull with on 150cc",
+    "",
+    "",
+    "",
+    "",
+    ""
+  ]
 }

--- a/object_parameters/GeoSplash.json
+++ b/object_parameters/GeoSplash.json
@@ -8,5 +8,15 @@
             "Unused",
             "Unused",
             "Unused"],
-  "Assets": ["Unknown"]
+  "Assets": ["Unknown"],
+  "Tooltips": [
+    "Must match the last value of the second hex number in your collision name, e.g. Roadtype_0x0100_0x5000010A, where A is the Index",
+    "1 = clear water, 3 = purple water, 5 = lava",
+    "",
+    "",
+    "",
+    "",
+    "",
+    ""
+  ]
 }

--- a/object_parameters/GeoSplash.json
+++ b/object_parameters/GeoSplash.json
@@ -10,7 +10,7 @@
             "Unused"],
   "Assets": ["Unknown"],
   "Tooltips": [
-    "Must match the last value of the second hex number in your collision name, e.g. Roadtype_0x0100_0x5000010A, where A is the Index",
+    "Must match the last value of the second hex number in your collision name, e.g. Roadtype_0x0100_0x50000107, where 7 is the Index",
     "1 = clear water, 3 = purple water, 5 = lava",
     "",
     "",

--- a/object_parameters/GeoTruck.json
+++ b/object_parameters/GeoTruck.json
@@ -8,5 +8,15 @@
             "Unknown 6",
             "Unknown 7",
             "Unknown 8"],
-  "Assets": ["car_truck1.bmd", "car_truck1.btk", "car_truck1.btp"]
+  "Assets": ["car_truck1.bmd", "car_truck1.btk", "car_truck1.btp"],
+  "Tooltips": [
+    "Vehicle speed",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    ""
+  ]
 }

--- a/widgets/data_editor.py
+++ b/widgets/data_editor.py
@@ -22,9 +22,16 @@ def load_parameter_names(objectname):
             data = json.load(f)
             parameter_names = data["Object Parameters"]
             assets = data["Assets"]
+            if "Tooltips" in data:
+                tooltips = data["Tooltips"]
+            else:
+                tooltips = ""
             if len(parameter_names) != 8:
                 raise RuntimeError("Not enough or too many parameters: {0} (should be 8)".format(len(parameter_names)))
-            return parameter_names, assets
+            if tooltips != "":
+                return parameter_names, assets, tooltips
+            else:
+                return parameter_names, assets
     except Exception as err:
         print(err)
         return None, None
@@ -853,12 +860,17 @@ class ObjectEdit(DataEditor):
         self.assets.setSizePolicy(hint)
 
     def rename_object_parameters(self, current):
-        parameter_names, assets = load_parameter_names(current)
+
+        if len(load_parameter_names(current)) == 2:
+            parameter_names, assets = load_parameter_names(current)
+        else:
+            parameter_names, assets, tooltips = load_parameter_names(current)
         if parameter_names is None:
             for i in range(8):
                 self.userdata[i][0].setText("Obj Data {0}".format(i+1))
                 self.userdata[i][0].setVisible(True)
                 self.userdata[i][1].setVisible(True)
+                self.userdata[i][1].setToolTip('')
             self.assets.setText("Required Assets: Unknown")
         else:
             for i in range(8):
@@ -873,6 +885,9 @@ class ObjectEdit(DataEditor):
                     self.userdata[i][0].setVisible(True)
                     self.userdata[i][1].setVisible(True)
                     self.userdata[i][0].setText(parameter_names[i])
+                    self.userdata[i][1].setToolTip('')
+                    if len(load_parameter_names(current)) == 3:
+                        self.userdata[i][1].setToolTip(tooltips[i])
             if len(assets) == 0:
                 self.assets.setText("Required Assets: None")
             else:

--- a/widgets/data_editor.py
+++ b/widgets/data_editor.py
@@ -1,5 +1,6 @@
 import os
 import json
+import widgets.tooltip_list as ttl
 
 from PyQt5 import QtCore, QtGui, QtWidgets
 
@@ -607,9 +608,13 @@ class EnemyPointEdit(DataEditor):
                                                         -inf, +inf)
         self.link = self.add_integer_input("Link", "link",
                                            MIN_SIGNED_SHORT, MAX_SIGNED_SHORT)
+        self.link.setToolTip(ttl.enemypoints['Link'])
         self.scale = self.add_decimal_input("Scale", "scale", -inf, inf)
+        self.scale.setToolTip(ttl.enemypoints['Scale'])
         self.itemsonly = self.add_checkbox("Items Only", "itemsonly", off_value=0, on_value=1)
+        self.itemsonly.setToolTip(ttl.enemypoints['Items Only'])
         self.swerve = self.add_dropdown_input("Swerve", "swerve", REVERSE_SWERVE_IDS)
+        self.swerve.setToolTip(ttl.enemypoints['Swerve'])
         self.group = self.add_integer_input("Group", "group",
                                             MIN_UNSIGNED_BYTE, MAX_UNSIGNED_BYTE)
         if not group_editable:
@@ -617,14 +622,19 @@ class EnemyPointEdit(DataEditor):
 
         self.driftdirection = self.add_dropdown_input("Drift Direction", "driftdirection",
                                                       DRIFT_DIRECTION_OPTIONS)
+        self.driftdirection.setToolTip(ttl.enemypoints['Drift Direction'])
         self.driftacuteness = self.add_integer_input("Drift Acuteness", "driftacuteness",
                                                      MIN_UNSIGNED_BYTE, 250)
+        self.driftacuteness.setToolTip(ttl.enemypoints['Drift Acuteness'])
         self.driftduration = self.add_integer_input("Drift Duration", "driftduration",
                                                     MIN_UNSIGNED_BYTE, MAX_UNSIGNED_BYTE)
+        self.driftduration.setToolTip(ttl.enemypoints['Drift Duration'])
         self.driftsupplement = self.add_integer_input("Drift Supplement", "driftsupplement",
                                                       MIN_UNSIGNED_BYTE, MAX_UNSIGNED_BYTE)
+        self.driftsupplement.setToolTip(ttl.enemypoints['Drift Direction'])
         self.nomushroomzone = self.add_checkbox("No Mushroom Zone", "nomushroomzone",
                                                 off_value=0, on_value=1)
+        self.nomushroomzone.setToolTip(ttl.enemypoints['No Mushroom Zone'])
 
         for widget in self.position:
             widget.editingFinished.connect(self.catch_text_update)
@@ -824,18 +834,27 @@ class ObjectEdit(DataEditor):
 
         self.pathid = self.add_integer_input("Route ID", "pathid",
                                              MIN_SIGNED_SHORT, MAX_SIGNED_SHORT)
+        self.pathid.setToolTip(ttl.objectdata['Route ID'])
 
         self.unk_28 = self.add_integer_input("Unknown 0x28", "unk_28",
                                              MIN_UNSIGNED_SHORT, MAX_UNSIGNED_SHORT)
 
         self.unk_2a = self.add_integer_input("Route Point ID", "unk_2a",
                                              MIN_SIGNED_SHORT, MAX_SIGNED_SHORT)
+        self.unk_2a.setToolTip(ttl.objectdata['Route Point ID'])
+
         self.presence_filter = self.add_integer_input("Presence Mask", "presence_filter",
                                                       MIN_UNSIGNED_BYTE, MAX_UNSIGNED_BYTE)
+        self.presence_filter.setToolTip(ttl.objectdata['Presence Mask'])
+
         self.presence = self.add_integer_input("Presence", "presence",
                                                MIN_UNSIGNED_BYTE, MAX_UNSIGNED_BYTE)
+        self.presence.setToolTip(ttl.objectdata['Presence'])
+
         self.flag = self.add_checkbox("Collision", "unk_flag",
                                       off_value=0, on_value=1)
+        self.flag.setToolTip(ttl.objectdata['Collision'])
+
         self.unk_2f = self.add_integer_input("Unknown 0x2F", "unk_2f",
                                              MIN_UNSIGNED_BYTE, MAX_UNSIGNED_BYTE)
 

--- a/widgets/tooltip_list.py
+++ b/widgets/tooltip_list.py
@@ -1,0 +1,19 @@
+objectdata = {
+    "Route ID": "The ID of the Route Group this object will follow (if supported by the object)",
+    "Route Point ID": "The ID of the Route Point this object will start from (if supported by the object)",
+    "Presence Mask": "255 = will show up in time trial and other modes. 15 = won't show up in time trial",
+    "Presence": "1 = only single screen modes. 2 = only split screen modes. 3 = both modes",
+    "Collision": "Whether the object can be physically interacted with or not (check vanilla courses for your desired object's effect)"
+}
+
+enemypoints = {
+    "Link": "Will link the point to another point with the same Link value. Set to -1 for no link.",
+    "Scale": "How wide of an area CPUs can drive on",
+    "Items Only": "Whether this Point is usable by CPUs or only items (red/blue shells, eggs)",
+    "Swerve": "Tells the CPUs to swerve left or right and how strongly",
+    "Drift Direction": "Gives CPUs the suggestion to drift at this point",
+    "Drift Acuteness": "How sharp the drift should be (in degrees). 250 max, 10 min",
+    "Drift Duration": "How long the drift should last for (in frames). 250 max, 30 min",
+    "Drift Supplement": "Value added to the calculation of all previous settings. Leave as 0 if unsure",
+    "No Mushroom Zone": "Whether CPUs are allowed to use mushrooms at this point or not"
+}


### PR DESCRIPTION
The user can now get short explanations for several objects and enemy points' properties by hovering the mouse over their input fields. For objects, tooltips are stored inside their respective object.json file on a new optional key called 'Tooltips'. For everything else, they're inside tooltip_list.py.

![image](https://user-images.githubusercontent.com/19808950/231022959-87857de8-1f0f-4eae-9b42-779c9a03a028.png)
