### PR TITLE
Provide the `SideWidget` with a scroll area.

### DIFF
--- a/widgets/side_widget.py
+++ b/widgets/side_widget.py
@@ -1,40 +1,18 @@
-from PyQt5.QtGui import QMouseEvent, QWheelEvent, QPainter, QColor, QFont, QFontMetrics, QPolygon, QImage, QPixmap, QKeySequence
-from PyQt5.QtWidgets import (QWidget, QListWidget, QListWidgetItem, QDialog, QMenu, QLineEdit,
-                            QMdiSubWindow, QHBoxLayout, QVBoxLayout, QLabel, QPushButton, QTextEdit, QAction, QShortcut)
-import PyQt5.QtWidgets as QtWidgets
-import PyQt5.QtCore as QtCore
-from PyQt5.QtCore import QSize, pyqtSignal, QPoint, QRect
-from PyQt5.QtCore import Qt
+from PyQt5 import QtCore, QtWidgets, QtGui
+
 from widgets.data_editor import choose_data_editor
 from widgets.more_buttons import MoreButtons
 
-class PikminSideWidget(QWidget):
+
+class PikminSideWidget(QtWidgets.QWidget):
+
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        parent = args[0]
 
-        self.parent = parent
-
-        self.verticalLayout = QVBoxLayout(self)
-        self.verticalLayout.setAlignment(Qt.AlignTop)
-
-        font = QFont()
-        font.setFamily("Consolas")
-        font.setStyleHint(QFont.Monospace)
-        font.setFixedPitch(True)
-        font.setPointSize(9)
-
-        self.verticalLayout.setObjectName("verticalLayout")
-
-        self.button_add_object = QPushButton(parent)
-
-        self.button_remove_object = QPushButton(parent)
-        self.button_ground_object = QPushButton(parent)
-        #self.button_move_object = QPushButton(parent)
-        #self.button_edit_object = QPushButton(parent)
-
-        #self.button_add_object.setDisabled(True)
-        #self.button_remove_object.setDisabled(True)
+        # Top bottoms.
+        self.button_add_object = QtWidgets.QPushButton()
+        self.button_remove_object = QtWidgets.QPushButton()
+        self.button_ground_object = QtWidgets.QPushButton()
 
         self.button_add_object.setText("Add Object")
         self.button_remove_object.setText("Remove Object(s)")
@@ -44,141 +22,113 @@ class PikminSideWidget(QWidget):
         self.button_remove_object.setToolTip("Hotkey: Delete")
         self.button_ground_object.setToolTip("Hotkey: G")
 
-
         self.button_add_object.setCheckable(True)
-        #self.button_move_object.setCheckable(True)
 
-        #self.lineedit_coordinatex = QLineEdit(parent)
-        #self.lineedit_coordinatey = QLineEdit(parent)
-        #self.lineedit_coordinatez = QLineEdit(parent)
-        #self.verticalLayout.addStretch(10)
-        #self.lineedit_rotationx = QLineEdit(parent)
-        #self.lineedit_rotationy = QLineEdit(parent)
-        #self.lineedit_rotationz = QLineEdit(parent)
-        self.verticalLayout.addWidget(self.button_add_object)
-        self.verticalLayout.addWidget(self.button_remove_object)
-        self.verticalLayout.addWidget(self.button_ground_object)
-        #self.verticalLayout.addWidget(self.button_move_object)
-
-        self.more_buttons = MoreButtons(parent)
+        # More buttons.
+        self.more_buttons = MoreButtons(None)
         self.more_buttons.add_buttons(None)
-        self.verticalLayout.addWidget(self.more_buttons)
 
-        self.verticalLayout.addStretch(20)
+        # Scroll area.
+        scroll_area = QtWidgets.QScrollArea()
+        scroll_area.setWidgetResizable(True)
+        scroll_area.setFrameStyle(QtWidgets.QFrame.NoFrame)
+        scroll_area.setFrameShape(QtWidgets.QFrame.NoFrame)
+        scroll_area_frame = QtWidgets.QFrame()
+        scroll_area_frame.setFrameStyle(QtWidgets.QFrame.StyledPanel)
+        palette = scroll_area_frame.palette()
+        palette.setBrush(scroll_area_frame.backgroundRole(), palette.dark())
+        scroll_area_frame.setPalette(palette)
+        self.scroll_area_frame_layout = QtWidgets.QVBoxLayout(scroll_area_frame)
+        self.scroll_area_frame_layout.addStretch(0)
+        self.scroll_area_frame_layout.setSpacing(self.fontMetrics().height())
+        scroll_area.setWidget(scroll_area_frame)
 
-        self.name_label = QLabel(parent)
+        font = QtGui.QFont()
+        font.setFamily("Consolas")
+        font.setStyleHint(QtGui.QFont.Monospace)
+        font.setFixedPitch(True)
+        font.setPointSize(round(font.pointSize() * 0.9))
+
+        # Name label.
+        self.name_label = QtWidgets.QLabel()
         self.name_label.setFont(font)
         self.name_label.setWordWrap(True)
-        self.name_label.setMinimumSize(self.name_label.width(), 30)
-        #self.identifier_label = QLabel(parent)
-        #self.identifier_label.setFont(font)
-        #self.identifier_label.setMinimumSize(self.name_label.width(), 50)
-        #self.identifier_label.setTextInteractionFlags(Qt.TextSelectableByMouse)
-        self.verticalLayout.addWidget(self.name_label)
-        #self.verticalLayout.addWidget(self.identifier_label)
+        self.scroll_area_frame_layout.addWidget(self.name_label)
 
-        """self.verticalLayout.addWidget(self.lineedit_coordinatex)
-        self.verticalLayout.addWidget(self.lineedit_coordinatey)
-        self.verticalLayout.addWidget(self.lineedit_coordinatez)
-
-        self.verticalLayout.addLayout(self._make_labeled_lineedit(self.lineedit_coordinatex, "X:   "))
-        self.verticalLayout.addLayout(self._make_labeled_lineedit(self.lineedit_coordinatey, "Y:   "))
-        self.verticalLayout.addLayout(self._make_labeled_lineedit(self.lineedit_coordinatez, "Z:   "))
-        self.verticalLayout.addStretch(10)
-        self.verticalLayout.addLayout(self._make_labeled_lineedit(self.lineedit_rotationx, "RotX:"))
-        self.verticalLayout.addLayout(self._make_labeled_lineedit(self.lineedit_rotationy, "RotY:"))
-        self.verticalLayout.addLayout(self._make_labeled_lineedit(self.lineedit_rotationz, "RotZ:"))"""
-        #self.verticalLayout.addStretch(10)
-        self.comment_label = QLabel(parent)
-        self.comment_label.setTextInteractionFlags(Qt.TextSelectableByMouse)
+        # Comment label.
+        self.comment_label = QtWidgets.QLabel()
+        self.comment_label.setTextInteractionFlags(QtCore.Qt.TextSelectableByMouse)
         self.comment_label.setWordWrap(True)
         self.comment_label.setFont(font)
-        self.verticalLayout.addWidget(self.comment_label)
-        #self.verticalLayout.addStretch(500)
+        self.scroll_area_frame_layout.addWidget(self.comment_label)
+        self.comment_label.hide()
 
-        self.objectlist = []
-
+        # Data editor.
         self.object_data_edit = None
+
+        # Main layout.
+        verticalLayout = QtWidgets.QVBoxLayout(self)
+        verticalLayout.addWidget(self.button_add_object)
+        verticalLayout.addWidget(self.button_remove_object)
+        verticalLayout.addWidget(self.button_ground_object)
+        verticalLayout.addWidget(self.more_buttons)
+        verticalLayout.addWidget(scroll_area)
 
         self.reset_info()
 
-    def _make_labeled_lineedit(self, lineedit, label):
-        font = QFont()
-        font.setFamily("Consolas")
-        font.setStyleHint(QFont.Monospace)
-        font.setFixedPitch(True)
-        font.setPointSize(10)
-
-        layout = QHBoxLayout()
-        label = QLabel(label, self)
-        label.setFont(font)
-        layout.addWidget(label)
-        layout.addWidget(lineedit)
-        return layout
-
     def reset_info(self, info="None selected"):
         self.name_label.setText(info)
-        #self.identifier_label.setText("")
         self.comment_label.setText("")
+        self.comment_label.hide()
 
         if self.object_data_edit is not None:
             self.object_data_edit.deleteLater()
-            del self.object_data_edit
             self.object_data_edit = None
-
-        self.objectlist = []
 
     def update_info(self):
         if self.object_data_edit is not None:
             self.object_data_edit.update_data()
 
-    def set_info(self, obj, update3d, usedby=[]):
+    def set_info(self, obj, update3d, usedby=tuple()):
         if usedby:
-            self.name_label.setText("Selected: {}\nUsed by: {}".format(type(obj).__name__,
-                                    ", ".join(usedby)))
+            self.name_label.setText("Selected: {}\nUsed by: {}".format(
+                type(obj).__name__, ", ".join(usedby)))
         else:
             self.name_label.setText("Selected: {}".format(type(obj).__name__))
-        #self.identifier_label.setText(obj.get_identifier())
+
         if self.object_data_edit is not None:
-            #self.verticalLayout.removeWidget(self.object_data_edit)
             self.object_data_edit.deleteLater()
-            del self.object_data_edit
             self.object_data_edit = None
-            print("should be removed")
 
         editor = choose_data_editor(obj)
         if editor is not None:
-
             self.object_data_edit = editor(self, obj)
-            self.verticalLayout.addWidget(self.object_data_edit)
+            self.scroll_area_frame_layout.addWidget(self.object_data_edit)
             self.object_data_edit.emit_3d_update.connect(update3d)
 
-        self.objectlist = []
         self.comment_label.setText("")
+        self.comment_label.hide()
 
     def set_objectlist(self, objs):
-        self.objectlist = []
         objectnames = []
 
         for obj in objs:
             if len(objectnames) < 25:
-                if hasattr(obj, "name"):
+                if hasattr(obj, "name") and obj.name != 'null':
                     objectnames.append(obj.name)
-            self.objectlist.append(obj)
 
-        objectnames.sort()
-        if len(objs) > 0:
-            text = "Selected objects:\n" + (", ".join(objectnames))
+        text = ''
+        if objectnames:
+            objectnames.sort()
+            text = f"Selected objects: {', '.join(objectnames)}"
             diff = len(objs) - len(objectnames)
-            if diff == 1:
-                text += "\nAnd {0} more object".format(diff)
-            elif diff > 1:
-                text += "\nAnd {0} more objects".format(diff)
-
-        else:
-            text = ""
+            if diff:
+                text += f"\n...and {diff} more object{'s' if diff > 1 else ''}"
+        elif objs:
+            text = f"Selected objects: {len(objs)}"
 
         self.comment_label.setText(text)
+        self.comment_label.setVisible(bool(text))
 
     def set_buttons(self, obj):
         self.more_buttons.add_buttons(obj)


### PR DESCRIPTION
The scroll area is added to stop the `SideWidget` from dictating the minimum width of its container (the splitter in the main window). If the data editor of the given selection grows larger than the width of the splitter, a scroll bar is now shown, instead of resizing the splitter (and thus the viewport).

| Before | After |
| --- | --- |
| <img src="https://user-images.githubusercontent.com/1853278/235298892-063f0a40-b40e-4987-9851-e31d9f888d99.png" alt="SideWidget - Before" title="SideWidget - Before" width="240"/> | <img src="https://user-images.githubusercontent.com/1853278/235298896-d51d1e16-089f-4d16-bdb6-474fe0e70084.png" alt="SideWidget - After" title="SideWidget - After" width="240"/> |

Bonus changes:

- Imports have been tidied up, removing unused imports, and avoiding to pollute the global namespace.
- Debugging prints have been removed.
- Spacing between name label and main data editor is now based on font sized, as opposed to hard-coded values.
- A number of other redundant lines, commented code, and unused functions have been removed.
- Font size is now determined based on a fraction of the initial font size, as opposed to hard-coding an arbitrary, fixed point size.
- Comment label has been fixed up (although its usefulness is arguable and could perhaps be removed entirely in the next iteration).