### PR TITLE
Fix a number of typos that break the framing functionality.

### DIFF
--- a/mkdd_editor.py
+++ b/mkdd_editor.py
@@ -488,19 +488,19 @@ class GenEditor(QMainWindow):
             min_x = min(x for x, _y, _z in vertices)
             min_y = min(y for _x, y, _z in vertices)
             min_z = min(z for _x, _y, z in vertices)
-            max_y = max(y for _x, y, _z in vertices)
             max_x = max(x for x, _y, _z in vertices)
+            max_y = max(y for _x, y, _z in vertices)
             max_z = max(z for _x, _y, z in vertices)
 
             if extent:
                 extent[0] = min(extent[0], min_x)
                 extent[1] = min(extent[1], min_y)
                 extent[2] = min(extent[2], min_z)
-                extent[3] = max(extent[3], max_y)
-                extent[4] = max(extent[4], max_x)
+                extent[3] = max(extent[3], max_x)
+                extent[4] = max(extent[4], max_y)
                 extent[5] = max(extent[5], max_z)
             else:
-                extend.extend([min_x, min_y, min_z, max_y, max_x, max_z])
+                extent.extend([min_x, min_y, min_z, max_x, max_y, max_z])
 
         return tuple(extent) or (0, 0, 0, 0, 0, 0)
 


### PR DESCRIPTION
The `max_x` and `max_y` were inadvertently swapped, producing wrong results.

Also, when the user tried to frame only the alternate mesh, an exception was produced:

```
Traceback (most recent call last):
  File "mkdd_editor.py", line 753, in <lambda>
    lambda _checked: self.frame_selection(adjust_zoom=True))
  File "mkdd_editor.py", line 382, in frame_selection
    minx, miny, minz, maxx, maxy, maxz = self.compute_objects_extent(selected_only)
  File "mkdd_editor.py", line 503, in compute_objects_extent
    extend.extend([min_x, min_y, min_z, max_y, max_x, max_z])
AttributeError: 'function' object has no attribute 'extend'
```

`extend` was used where `extent` was expected.