### PR TITLE
Draw placeholder for the next checkpoint if its start position is already defined.

### DIFF
--- a/mkdd_editor.py
+++ b/mkdd_editor.py
@@ -149,7 +149,7 @@ class GenEditor(QMainWindow):
         self.bco_coll = None
         self.loaded_archive = None
         self.loaded_archive_file = None
-        self.last_position_clicked = []
+        self.next_checkpoint_start_position = None
 
         self._dontselectfromtree = False
 
@@ -219,7 +219,7 @@ class GenEditor(QMainWindow):
 
     @catch_exception
     def reset(self):
-        self.last_position_clicked = []
+        self.next_checkpoint_start_position = None
         self.loaded_archive = None
         self.loaded_archive_file = None
         self.object_to_be_added = None
@@ -2008,6 +2008,8 @@ class GenEditor(QMainWindow):
 
     def button_open_add_item_window(self):
         self.add_object_window.update_label()
+        self.next_checkpoint_start_position = None
+
         accepted = self.add_object_window.exec_()
         if accepted:
             self.add_item_window_save()
@@ -2101,10 +2103,12 @@ class GenEditor(QMainWindow):
             position = 99999999 # this forces insertion at the end of the list
 
         if isinstance(object, libbol.Checkpoint):
-            if len(self.last_position_clicked) == 1:
+            if self.next_checkpoint_start_position is not None:
                 placeobject = deepcopy(object)
 
-                x1, y1, z1 = self.last_position_clicked[0]
+                x1, y1, z1 = self.next_checkpoint_start_position
+                self.next_checkpoint_start_position = None
+
                 placeobject.start.x = x1
                 placeobject.start.y = y1
                 placeobject.start.z = z1
@@ -2112,7 +2116,7 @@ class GenEditor(QMainWindow):
                 placeobject.end.x = x
                 placeobject.end.y = y
                 placeobject.end.z = z
-                self.last_position_clicked = []
+
                 # For convenience, create a group if none exists yet.
                 if group == 0 and not self.level_file.checkpoints.groups:
                     self.level_file.checkpoints.groups.append(libbol.CheckpointGroup.new())
@@ -2136,7 +2140,7 @@ class GenEditor(QMainWindow):
 
                 self.select_tree_item_bound_to(placeobject)
             else:
-                self.last_position_clicked = [(x, y, z)]
+                self.next_checkpoint_start_position = (x, y, z)
 
         else:
             placeobject = deepcopy(object)
@@ -2283,6 +2287,7 @@ class GenEditor(QMainWindow):
 
         if event.key() == Qt.Key_Escape:
             self.level_view.set_mouse_mode(mkdd_widgets.MOUSE_MODE_NONE)
+            self.next_checkpoint_start_position = None
             self.pik_control.button_add_object.setChecked(False)
             #self.pik_control.button_move_object.setChecked(False)
 

--- a/mkdd_editor.py
+++ b/mkdd_editor.py
@@ -566,6 +566,7 @@ class GenEditor(QMainWindow):
 
         self.level_view = BolMapViewer(int(self.editorconfig.get("multisampling", 8)),
                                        self.centralwidget)
+        self.level_view.editor = self
 
         self.horizontalLayout.setObjectName("horizontalLayout")
         self.horizontalLayout.addWidget(self.leveldatatreeview)
@@ -2017,6 +2018,8 @@ class GenEditor(QMainWindow):
             self.level_view.set_mouse_mode(mkdd_widgets.MOUSE_MODE_NONE)
             self.pik_control.button_add_object.setChecked(False)
 
+        self.update_3d()
+
     def shortcut_open_add_item_window(self):
         self.button_open_add_item_window()
 
@@ -2290,6 +2293,7 @@ class GenEditor(QMainWindow):
             self.next_checkpoint_start_position = None
             self.pik_control.button_add_object.setChecked(False)
             #self.pik_control.button_move_object.setChecked(False)
+            self.update_3d()
 
         if event.key() == Qt.Key_Shift:
             self.level_view.shift_is_pressed = True

--- a/mkdd_widgets.py
+++ b/mkdd_widgets.py
@@ -1170,8 +1170,12 @@ class BolMapViewer(QtWidgets.QOpenGLWidget):
                     for checkpoint in group.points:
                         start_point_selected = checkpoint.start in positions
                         end_point_selected = checkpoint.end in positions
-                        self.models.render_generic_position_colored(checkpoint.start, checkpoint.start in positions, "checkpointleft")
-                        self.models.render_generic_position_colored(checkpoint.end, checkpoint.end in positions, "checkpointright")
+                        self.models.render_generic_position_colored(checkpoint.start,
+                                                                    start_point_selected,
+                                                                    "checkpointleft")
+                        self.models.render_generic_position_colored(checkpoint.end,
+                                                                    end_point_selected,
+                                                                    "checkpointright")
 
                         if start_point_selected or end_point_selected:
                             checkpoints_to_highlight.add(count)

--- a/mkdd_widgets.py
+++ b/mkdd_widgets.py
@@ -97,6 +97,8 @@ class BolMapViewer(QtWidgets.QOpenGLWidget):
     def __init__(self, samples, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
+        self.editor = None
+
         # Enable multisampling by setting the number of configured samples in the surface format.
         self.samples = samples
         if self.samples > 1:
@@ -1260,6 +1262,11 @@ class BolMapViewer(QtWidgets.QOpenGLWidget):
                             glVertex3f(mid2.x, -mid2.z, mid2.y)
                             prev = checkpoint
                 glEnd()
+
+                if self.editor.next_checkpoint_start_position is not None:
+                    self.models.render_generic_position_colored(
+                        Vector3(*self.editor.next_checkpoint_start_position), True,
+                        "checkpointleft")
 
             if vismenu.objects.is_visible():
                 for object in self.level_file.objects.objects:

--- a/mkdd_widgets.py
+++ b/mkdd_widgets.py
@@ -1233,33 +1233,22 @@ class BolMapViewer(QtWidgets.QOpenGLWidget):
                             point_index += 1
                     glLineWidth(1.0)
 
-            #glColor3f(1.0, 1.0, 1.0)
-            #glEnable(GL_TEXTURE_2D)
-            #glBindTexture(GL_TEXTURE_2D, self.arrow.tex)
-            glPushMatrix()
-            #lines = []
-            if vismenu.checkpoints.is_visible():
-                for group in self.level_file.checkpoints.groups:
+                for i, group in enumerate(self.level_file.checkpoints.groups):
+                    glColor3f(*colors[i % 4])
                     prev = None
                     for checkpoint in group.points:
                         if prev is None:
                             prev = checkpoint
                         else:
-                            #mid1 = prev.mid
-                            #mid2 = checkpoint.mid
                             mid1 = (prev.start + prev.end) / 2.0
                             mid2 = (checkpoint.start + checkpoint.end) / 2.0
 
                             self.models.draw_arrow_head(mid1, mid2)
-                            #lines.append((mid1, mid2))
                             prev = checkpoint
-            glPopMatrix()
-            glBegin(GL_LINES)
-            """for linestart, lineend in lines:
-                glVertex3f(linestart.x, -linestart.z, linestart.y)
-                glVertex3f(lineend.x, -lineend.z, lineend.y)"""
-            if vismenu.checkpoints.is_visible():
-                for group in self.level_file.checkpoints.groups:
+
+                glBegin(GL_LINES)
+                for i, group in enumerate(self.level_file.checkpoints.groups):
+                    glColor3f(*colors[i % 4])
                     prev = None
                     for checkpoint in group.points:
                         if prev is None:
@@ -1267,12 +1256,10 @@ class BolMapViewer(QtWidgets.QOpenGLWidget):
                         else:
                             mid1 = (prev.start+prev.end)/2.0
                             mid2 = (checkpoint.start+checkpoint.end)/2.0
-                            #mid1 = prev.mid
-                            #mid2 = checkpoint.mid
                             glVertex3f(mid1.x, -mid1.z, mid1.y)
                             glVertex3f(mid2.x, -mid2.z, mid2.y)
                             prev = checkpoint
-            glEnd()
+                glEnd()
 
             if vismenu.objects.is_visible():
                 for object in self.level_file.objects.objects:


### PR DESCRIPTION
<img src="https://user-images.githubusercontent.com/1853278/235306381-52382570-10b3-4b91-9863-f28da1f0e170.gif" alt="Draw Checkpoint Placeholder" title="Draw Checkpoint Placeholder" width="600"/>

Also, when object-insertion mode is abandoned, the stashed start position is now reset, preventing the user from creating borked checkpoints after re-entering object-insertion mode at a later time.