### PR TITLE
Add buttons for adding start points

### DIFF
--- a/mkdd_editor.py
+++ b/mkdd_editor.py
@@ -2250,6 +2250,10 @@ class GenEditor(QMainWindow):
             self.object_to_be_added = [libbol.RoutePoint.new(), group_id, pos + 1]
             self.pik_control.button_add_object.setChecked(True)
             self.level_view.set_mouse_mode(mkdd_widgets.MOUSE_MODE_ADDWP)
+        elif option == "add_startpoint":
+            self.object_to_be_added = [libbol.KartStartPoint.new(), -1, -1]
+            self.pik_control.button_add_object.setChecked(True)
+            self.level_view.set_mouse_mode(mkdd_widgets.MOUSE_MODE_ADDWP)
 
         self.leveldatatreeview.set_objects(self.level_file)
 

--- a/widgets/more_buttons.py
+++ b/widgets/more_buttons.py
@@ -11,8 +11,9 @@ class MoreButtons(QWidget):
     def add_button(self, obj, text, optionstring):
         new_button = QPushButton(self)
         new_button.setText(text)
+        gen_editor = self.parent().parent().parent()
         new_button.clicked.connect(
-            lambda: self.parent().parent.button_side_button_action(optionstring, obj))
+            lambda: gen_editor.button_side_button_action(optionstring, obj))
         self.vbox.addWidget(new_button)
 
     def add_buttons(self, option = None):
@@ -35,6 +36,12 @@ class MoreButtons(QWidget):
                 self.add_button(obj, "Add Route", "add_route")
         elif isinstance(obj, (Route, RoutePoint)):
             self.add_button(obj, "Add Route Points", "add_routepoints")
+        elif isinstance(obj, KartStartPoints):
+            #if len(obj.positions) == 0:
+            #^ this check should be performed when/if separate battle mode support is added
+            #or, someone needs to look into multiple starting points for regular courses
+            #i suspect that it's useless to add more than 1 point
+            self.add_button(obj, "Add Starting Point", "add_startpoint")
 
     def clear_buttons(self):
         for i in reversed(range(self.vbox.count())):


### PR DESCRIPTION
Make this easy. This could be improved by adding support for battle / regular track / staff demo variables to see how many start points need to be in a .bol, but that is for later. 