### PR TITLE
Avoid destroying and recreating side buttons repeteadly.

### DIFF
--- a/widgets/more_buttons.py
+++ b/widgets/more_buttons.py
@@ -6,47 +6,67 @@ from widgets.tree_view import BolHeader
 class MoreButtons(QtWidgets.QWidget):
     def __init__(self, parent):
         super().__init__(parent)
+
+        self._buttons = {}
+        self._target_obj = None
+
         self.vbox = QtWidgets.QVBoxLayout(self)
         self.vbox.setContentsMargins(0, 0, 0, 0)
 
-    def add_button(self, obj, text, optionstring):
+        self.add_button('Add Enemy Path', 'add_enemypath')
+        self.add_button('Add Enemy Points', 'add_enemypoints')
+        self.add_button('Add Checkpoint Group', 'add_checkpointgroup')
+        self.add_button('Add Checkpoints', 'add_checkpoints')
+        self.add_button('Add Route', 'add_route')
+        self.add_button('Add Route Points', 'add_routepoints')
+        self.add_button('Add Starting Point', 'add_startpoint')
+        self.add_button('Add Route for Object', 'route_object')
+
+    def add_button(self, text, optionstring):
         new_button = QtWidgets.QPushButton(self)
         new_button.setText(text)
-        gen_editor = self.parent().parent().parent()
-        new_button.clicked.connect(
-            lambda: gen_editor.button_side_button_action(optionstring, obj))
+        new_button.setObjectName(optionstring)
+        new_button.clicked.connect(self._on_button_clicked)
+
         self.vbox.addWidget(new_button)
+        new_button.hide()
+
+        self._buttons[optionstring] = new_button
 
     def add_buttons(self, option = None):
-        self.clear_buttons()
+        self._target_obj = obj = option.bound_to if hasattr(option, 'bound_to') else None
+        optionstring = None
 
-        if option is None or isinstance(option, BolHeader):
-            return
-
-        obj = option.bound_to
         if isinstance(obj, EnemyPointGroups):
-            self.add_button(obj, "Add Enemy Path", "add_enemypath")
+            optionstring = "add_enemypath"
         elif isinstance(obj, (EnemyPointGroup, EnemyPoint)):
-            self.add_button(obj, "Add Enemy Points", "add_enemypoints")
+            optionstring = "add_enemypoints"
         elif isinstance(obj, (CheckpointGroups)):
-            self.add_button(obj, "Add Checkpoint Group", "add_checkpointgroup")
+            optionstring = "add_checkpointgroup"
         elif isinstance(obj, (CheckpointGroup, Checkpoint)):
-            self.add_button(obj, "Add Checkpoints", "add_checkpoints")
+            optionstring = "add_checkpoints"
         elif isinstance(obj, ObjectContainer):
             if obj.object_type is Route:
-                self.add_button(obj, "Add Route", "add_route")
+                optionstring = "add_route"
         elif isinstance(obj, (Route, RoutePoint)):
-            self.add_button(obj, "Add Route Points", "add_routepoints")
+            optionstring = "add_routepoints"
         elif isinstance(obj, KartStartPoints):
             #if len(obj.positions) == 0:
             #^ this check should be performed when/if separate battle mode support is added
             #or, someone needs to look into multiple starting points for regular courses
             #i suspect that it's useless to add more than 1 point
-            self.add_button(obj, "Add Starting Point", "add_startpoint")
+            optionstring = "add_startpoint"
         elif isinstance(obj, MapObject):
             if obj.route_info() == "Individual" and obj.pathid == -1:
-                self.add_button(obj, "Add Route for Object", "route_object")
+                optionstring = "route_object"
 
-    def clear_buttons(self):
-        for i in reversed(range(self.vbox.count())):
-            self.vbox.itemAt(i).widget().setParent(None)
+        for name, button in self._buttons.items():
+            button.setVisible(name == optionstring)
+
+    def _on_button_clicked(self):
+        if self._target_obj is None:
+            return
+
+        gen_editor = self.parent().parent().parent()
+        optionstring = self.sender().objectName()
+        gen_editor.button_side_button_action(optionstring, self._target_obj)


### PR DESCRIPTION
Buttons are now created on startup; only their visibility changes when required.

The following exception (or a variation of it) could be seen when toggling between tree items, as the layout was stripped, and buttons were recreated:

```
Traceback (most recent call last):
  File "/w/mkdd-track-editor/mkdd_editor.py", line 2857, in notify
    return super().notify(receiver, event)
TypeError: 'PySide6.QtWidgets.QApplication.notify' called with wrong argument types:
  PySide6.QtWidgets.QApplication.notify(QWidgetItem, QEvent)
Supported signatures:
  PySide6.QtWidgets.QApplication.notify(PySide6.QtCore.QObject, PySide6.QtCore.QEvent)
```

The issue was only surfaced after migrating to PySide 6.2 / Qt 6.2 LTS.