### PR TITLE
Checkpoint tooltips, support for sections.

### DIFF
--- a/lib/libbol.py
+++ b/lib/libbol.py
@@ -605,9 +605,9 @@ class Checkpoint(object):
         start = Vector3(*unpack(">fff", f.read(12)))
         end = Vector3(*unpack(">fff", f.read(12)))
         unk1, unk2, unk3, unk4 = unpack(">BBBB", f.read(4))
-        assert unk4 == 0
         assert unk2 == 0 or unk2 == 1
         assert unk3 == 0 or unk3 == 1
+        assert unk4 in (0, 1)  # 1 expected only for the custom "Lap Checkpoint" parameter
         return cls(start, end, unk1, unk2, unk3, unk4)
 
     def write(self, f):

--- a/mkdd_widgets.py
+++ b/mkdd_widgets.py
@@ -36,6 +36,7 @@ MODE_3D = 1
 
 #colors = [(1.0, 0.0, 0.0), (0.0, 0.5, 0.0), (0.0, 0.0, 1.0), (1.0, 1.0, 0.0)]
 colors = [(0.0,191/255.0,255/255.0), (30/255.0,144/255.0,255/255.0), (0.0,0.0,255/255.0), (0.0,0.0,139/255.0)]
+lap_checkpoint_color = (115 / 255, 210 / 255, 22 / 255)
 
 with open("lib/color_coding.json", "r") as f:
     colors_json = json.load(f)
@@ -1267,6 +1268,7 @@ class BolMapViewer(QtOpenGLWidgets.QOpenGLWidget):
 
             if vismenu.checkpoints.is_visible():
                 checkpoints_to_highlight = set()
+                section_points = set()
                 count = 0
 
                 # Get all concave checkpoints
@@ -1293,6 +1295,7 @@ class BolMapViewer(QtOpenGLWidgets.QOpenGLWidget):
                     for checkpoint in group.points:
                         start_point_selected = checkpoint.start in positions
                         end_point_selected = checkpoint.end in positions
+                        is_sectionpoint = checkpoint.unk4 != 0
                         self.models.render_generic_position_colored(checkpoint.start,
                                                                     start_point_selected,
                                                                     "checkpointleft")
@@ -1302,6 +1305,10 @@ class BolMapViewer(QtOpenGLWidgets.QOpenGLWidget):
 
                         if start_point_selected or end_point_selected:
                             checkpoints_to_highlight.add(count)
+
+                        if is_sectionpoint:
+                            section_points.add(checkpoint)
+
                         count += 1
 
                     # Draw the lines between the points
@@ -1309,6 +1316,8 @@ class BolMapViewer(QtOpenGLWidgets.QOpenGLWidget):
                     for checkpoint in group.points:
                         if checkpoint in concave_checkpoints:
                             glColor3f(1.0, 0.0, 0.0)
+                        elif checkpoint in section_points:
+                            glColor3f(*lap_checkpoint_color)
                         else:
                             glColor3f(*colors[i % 4])
 
@@ -1354,6 +1363,8 @@ class BolMapViewer(QtOpenGLWidgets.QOpenGLWidget):
                             if point_index in checkpoints_to_highlight:
                                 if checkpoint in concave_checkpoints:
                                     glColor3f(1.0, 0.0, 0.0)
+                                elif checkpoint in section_points:
+                                    glColor3f(*lap_checkpoint_color)
                                 else:
                                     glColor3f(*colors[i % 4])
 

--- a/widgets/data_editor.py
+++ b/widgets/data_editor.py
@@ -841,12 +841,16 @@ class CheckpointEdit(DataEditor):
         self.end = self.add_multiple_decimal_input("End", "end", ["x", "y", "z"],
                                                      -inf, +inf)
 
-        self.unk1 = self.add_integer_input("Unknown", "unk1",
+        self.unk1 = self.add_integer_input("Shortcut Point ID", "unk1",
                                            MIN_UNSIGNED_BYTE, MAX_UNSIGNED_BYTE)
-        self.unk2 = self.add_checkbox("Unknown Flag", "unk2",
-                                      0, 1)
-        self.unk3 = self.add_checkbox("Unknown Flag 2", "unk3",
-                                           0, 1)
+        set_tool_tip(self.unk1, ttl.checkpoints["Shortcut Point ID"])
+        self.unk3 = self.add_checkbox("Double-sided", "unk3", 0, 1)
+        set_tool_tip(self.unk3, ttl.checkpoints["Double-sided"])
+
+        if self.get_bol_editor().show_code_patch_fields_action.isChecked():
+            self.unk4 = self.add_checkbox("Lap Checkpoint 🧩", "unk4", 0, 1)
+            self.unk4.toggled.connect(self.catch_text_update)
+            set_tool_tip(self.unk4, ttl.checkpoints["Lap Checkpoint"])
 
     def update_data(self):
         obj: Checkpoint = self.bound_to
@@ -859,8 +863,10 @@ class CheckpointEdit(DataEditor):
         self.end[2].setValueQuiet(obj.end.z)
 
         self.unk1.setValueQuiet(obj.unk1)
-        self.unk2.setChecked(obj.unk2 != 0)
         self.unk3.setChecked(obj.unk3 != 0)
+
+        if self.get_bol_editor().show_code_patch_fields_action.isChecked():
+            self.unk4.setChecked(obj.unk4 != 0)
 
 
 class ObjectRouteEdit(DataEditor):

--- a/widgets/tooltip_list.py
+++ b/widgets/tooltip_list.py
@@ -49,6 +49,12 @@ enemypoints = tool_tips_markdown_to_html({
     "No Mushroom Zone": "Whether CPUs are allowed to use mushrooms at this point or not",
 })
 
+checkpoints = tool_tips_markdown_to_html({
+    "Shortcut Point ID": "After this point is crossed, all regions containing checkpoint pairs with this ID will cause the lap checker to be halted, allowing for dev-intended shortcuts.\nOnce the region is left, the lap checker will jump to the next standard checkpoint.",
+    "Double-sided": "If set, the game will check if this point has been crossed from the opposite side.",
+    "Lap Checkpoint": "🧩 Requires the **Sectioned Courses** code patch.\n\nWhen crossed, a lap will be incremented. \nIf this is the last checkpoint of its kind, the race will be finished instead.\nIf **Shortcut Point ID** is set, this flag is ignored, and a lap will _not_ be counted.\n\n---\n<small>**IMPORTANT:** Custom tracks that utilize this property must include `sectioned-courses` in the **code_patches** field in the `trackinfo.ini` file of the custom track.</small>",
+})
+
 objectid = tool_tips_markdown_to_html({
     "GeoAirJet": "The blowing wind from Sherbet Land",
     "GeoMarioFlower1": "The flowers with eyes from several tracks",


### PR DESCRIPTION
(Yes, this is a duplicate of a prior PR)

Removes the assertion and allows edits to the fourth parameter of a checkpoint, which the "[Sectioned Courses](https://github.com/cristian64/mkdd-extender/pull/22)" patch depends on for lap-forcing.

Along with that, I've added some tooltips and labels for checkpoints, based on the information [here](https://mkdd.miraheze.org/wiki/BOL_(File_Format)#Sections).