### PR TITLE
Widget types for object-specific parameters.

### DIFF
--- a/lib/libbol.py
+++ b/lib/libbol.py
@@ -1,3 +1,4 @@
+import functools
 import json
 from struct import unpack, pack
 from numpy import ndarray, array, argmin
@@ -67,6 +68,15 @@ def write_padding(f, multiple):
     for i in range(diff):
         pos = i % len(PADDING)
         f.write(PADDING[pos:pos + 1])
+
+
+@functools.lru_cache
+def read_object_parameters(name: str) -> dict:
+    filepath = os.path.join('object_parameters', f'{name}.json')
+    if not os.path.isfile(filepath):
+        return None
+    with open(filepath, "r", encoding='utf-8') as f:
+        return json.load(f)
 
 
 class Rotation(object):
@@ -729,15 +739,9 @@ class MapObject(object):
         #assert f.tell() - start == self._size
 
     def read_json_file(self):
-        if not self.objectid in OBJECTNAMES:
+        if self.objectid not in OBJECTNAMES:
             return None
-        name = OBJECTNAMES[self.objectid]
-        filename = os.path.join("object_parameters", name + ".json")
-        if not os.path.isfile(filename):
-            return None
-        with open(filename, "r", encoding='utf-8') as f:
-            json_data = json.load(f)
-        return json_data
+        return read_object_parameters(OBJECTNAMES[self.objectid])
 
     def route_info(self):
         json_data = self.read_json_file()

--- a/object_parameters/GeoCannon.json
+++ b/object_parameters/GeoCannon.json
@@ -2,7 +2,7 @@
     "Object Parameters": [
         "Respawn ID",
         "Unknown 2",
-        "Invisibility",
+        "Invisible",
         "Sound Effect",
         "Unused",
         "Unused",
@@ -17,8 +17,8 @@
     "Tooltips": [
         "The Respawn ID that the cannon will shoot towards",
         "",
-        "0 = visible\n1 = invisible",
-        "0 = Lots of screaming with a longer duration.\n1 = A single scream, no landing sound.\n2 = A single scream, with landing sound.",
+        "",
+        "The sound that characters make while they are airborne.",
         "",
         "",
         "",
@@ -29,10 +29,20 @@
         0,
         0,
         0,
-        1,
+        2,
         0,
         0,
         0,
         0
+    ],
+    "Widgets": [
+        null,
+        null,
+        "checkbox",
+        ["combobox", {"Long Screaming": 0, "Single Scream (no landing sound)": 1, "Single Scream": 2}],
+        null,
+        null,
+        null,
+        null
     ]
 }

--- a/object_parameters/GeoF_ItemBox.json
+++ b/object_parameters/GeoF_ItemBox.json
@@ -1,8 +1,8 @@
 {
     "Object Parameters": [
         "Height Offset",
-        "ItemBox Type",
-        "Unused",
+        "Item Box Type",
+        "Always Special Item",
         "Unused",
         "Unused",
         "Unused",
@@ -11,9 +11,9 @@
     ],
     "Assets": [],
     "Tooltips": [
-        "How high off the ground the itembox will be. Itembox must be grounded and this set to 135.",
-        "Whether itembox is single or double:\n0 = both\n1 = single only\n3 = double only",
-        "",
+        "How high off the ground the item box will be. Usually item boxes are grounded with this field set to 135.",
+        "Whether the item box is single or double.",
+        "A special item will be always given if the item box is single, and only if the player's current position can have special items. Enabling Frantic mode, and setting the item box type to always single will ensure that a special item is always given.",
         "",
         "",
         "",
@@ -30,5 +30,15 @@
         0,
         0,
         0
+    ],
+    "Widgets": [
+        null,
+        ["combobox", {"Single or Double": 0, "Single": 1, "Double": 3}],
+        "checkbox",
+        null,
+        null,
+        null,
+        null,
+        null
     ]
 }

--- a/object_parameters/GeoItemBox.json
+++ b/object_parameters/GeoItemBox.json
@@ -1,8 +1,8 @@
 {
     "Object Parameters": [
         "Height Offset",
-        "ItemBox Type",
-        "Unused",
+        "Item Box Type",
+        "Always Special Item",
         "Unused",
         "Unused",
         "Unused",
@@ -11,9 +11,9 @@
     ],
     "Assets": [],
     "Tooltips": [
-        "How high off the ground the itembox will be. Itembox must be grounded and this set to 135.",
-        "Whether itembox is single or double:\n0 = both\n1 = single only\n3 = double only",
-        "",
+        "How high off the ground the item box will be. Usually item boxes are grounded with this field set to 135.",
+        "Whether the item box is single or double.",
+        "A special item will be always given if the item box is single, and only if the player's current position can have special items. Enabling Frantic mode, and setting the item box type to always single will ensure that a special item is always given.",
         "",
         "",
         "",
@@ -30,5 +30,15 @@
         0,
         0,
         0
+    ],
+    "Widgets": [
+        null,
+        ["combobox", {"Single or Double": 0, "Single": 1, "Double": 3}],
+        "checkbox",
+        null,
+        null,
+        null,
+        null,
+        null
     ]
 }

--- a/object_parameters/GeoShimmer.json
+++ b/object_parameters/GeoShimmer.json
@@ -22,5 +22,15 @@
         0,
         0,
         0
+    ],
+    "Widgets": [
+        "checkbox",
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null
     ]
 }

--- a/object_parameters/TMapObjAwardItemBox.json
+++ b/object_parameters/TMapObjAwardItemBox.json
@@ -1,8 +1,8 @@
 {
     "Object Parameters": [
         "Height Offset",
-        "ItemBox Type",
-        "Unused",
+        "Item Box Type",
+        "Always Special Item",
         "Unused",
         "Unused",
         "Unused",
@@ -11,9 +11,9 @@
     ],
     "Assets": [],
     "Tooltips": [
-        "How high off the ground the itembox will be. Itembox must be grounded and this set to 135.",
-        "Whether itembox is single or double:\n0 = both\n1 = single only\n3 = double only",
-        "",
+        "How high off the ground the item box will be. Usually item boxes are grounded with this field set to 135.",
+        "Whether the item box is single or double.",
+        "A special item will be always given if the item box is single, and only if the player's current position can have special items. Enabling Frantic mode, and setting the item box type to always single will ensure that a special item is always given.",
         "",
         "",
         "",
@@ -30,5 +30,15 @@
         0,
         0,
         0
+    ],
+    "Widgets": [
+        null,
+        ["combobox", {"Single or Double": 0, "Single": 1, "Double": 3}],
+        "checkbox",
+        null,
+        null,
+        null,
+        null,
+        null
     ]
 }

--- a/object_parameters/TMapObjMoveItemBox.json
+++ b/object_parameters/TMapObjMoveItemBox.json
@@ -1,19 +1,19 @@
 {
     "Object Parameters": [
-        "Unknown 1",
-        "Unknown 2",
-        "Unknown 3",
-        "Unknown 4",
-        "Unknown 5",
-        "Unknown 6",
-        "Unknown 7",
-        "Unknown 8"
+        "Height Offset",
+        "Item Box Type",
+        "Always Special Item",
+        "Unused",
+        "Unused",
+        "Unused",
+        "Unused",
+        "Unused"
     ],
     "Assets": [],
     "Tooltips": [
-        "",
-        "",
-        "",
+        "How high off the ground the item box will be. Usually item boxes are grounded with this field set to 135.",
+        "Whether the item box is single or double.",
+        "A special item will be always given if the item box is single, and only if the player's current position can have special items. Enabling Frantic mode, and setting the item box type to always single will ensure that a special item is always given.",
         "",
         "",
         "",
@@ -22,7 +22,7 @@
     ],
     "RouteInfo": "None",
     "DefaultValues": [
-        0,
+        135,
         0,
         0,
         0,
@@ -30,5 +30,15 @@
         0,
         0,
         0
+    ],
+    "Widgets": [
+        null,
+        ["combobox", {"Single or Double": 0, "Single": 1, "Double": 3}],
+        "checkbox",
+        null,
+        null,
+        null,
+        null,
+        null
     ]
 }

--- a/object_parameters/TMapObjMoveItemBoxLimit.json
+++ b/object_parameters/TMapObjMoveItemBoxLimit.json
@@ -1,19 +1,19 @@
 {
     "Object Parameters": [
-        "Unknown 1",
-        "Unknown 2",
-        "Unknown 3",
-        "Unknown 4",
-        "Unknown 5",
-        "Unknown 6",
-        "Unknown 7",
-        "Unknown 8"
+        "Height Offset",
+        "Item Box Type",
+        "Always Special Item",
+        "Unused",
+        "Unused",
+        "Unused",
+        "Unused",
+        "Unused"
     ],
     "Assets": [],
     "Tooltips": [
-        "",
-        "",
-        "",
+        "How high off the ground the item box will be. Usually item boxes are grounded with this field set to 135.",
+        "Whether the item box is single or double.",
+        "A special item will be always given if the item box is single, and only if the player's current position can have special items. Enabling Frantic mode, and setting the item box type to always single will ensure that a special item is always given.",
         "",
         "",
         "",
@@ -30,5 +30,15 @@
         0,
         0,
         0
+    ],
+    "Widgets": [
+        null,
+        ["combobox", {"Single or Double": 0, "Single": 1, "Double": 3}],
+        "checkbox",
+        null,
+        null,
+        null,
+        null,
+        null
     ]
 }

--- a/widgets/data_editor.py
+++ b/widgets/data_editor.py
@@ -36,7 +36,23 @@ def load_parameter_names(objectname):
 
     except Exception as err:
         print(err)
-        return None, None, None
+        return (
+            tuple(f'Obj Data {i + 1}' for i in range(8)),
+            tuple(),
+            tuple([''] * 8),
+            tuple([None] * 8),
+        )
+
+
+def clear_layout(layout):
+    while layout.count():
+        child = layout.itemAt(0)
+        if child.widget():
+            child.widget().deleteLater()
+        if child.layout():
+            clear_layout(child.layout())
+            child.layout().deleteLater()
+        layout.takeAt(0)
 
 
 class PythonIntValidator(QtGui.QValidator):
@@ -286,24 +302,6 @@ class DataEditor(QtWidgets.QWidget):
         print("created for", text, attribute)
         return line_edit
 
-    def add_integer_input_index(self, text, attribute, index, min_val, max_val):
-        line_edit = QtWidgets.QLineEdit(self)
-        layout = self.create_labeled_widget(self, text, line_edit)
-
-        line_edit.setValidator(QtGui.QIntValidator(min_val, max_val, self))
-
-        def input_edited():
-            text = line_edit.text()
-            print("input:", text)
-            mainattr = getattr(self.bound_to, attribute)
-            mainattr[index] = int(text)
-
-        line_edit.editingFinished.connect(input_edited)
-        label = layout.itemAt(0).widget()
-        self.vbox.addLayout(layout)
-
-        return label, line_edit
-
     def add_decimal_input(self, text, attribute, min_val, max_val):
         line_edit = QtWidgets.QLineEdit(self)
         layout = self.create_labeled_widget(self, text, line_edit)
@@ -487,6 +485,36 @@ class DataEditor(QtWidgets.QWidget):
         self.vbox.addLayout(layout)
 
         return line_edits
+
+    def add_types_widget_index(self, layout, text, attribute, index, widget_type):
+        # Certain widget types will be accompanied with arguments.
+        if isinstance(widget_type, (list, tuple)):
+            widget_type, *widget_type_args = widget_type
+
+        def set_value(value, index=index):
+            getattr(self.bound_to, attribute)[index] = value
+
+        if widget_type == "checkbox":
+            widget = QtWidgets.QCheckBox()
+            widget.stateChanged.connect(lambda state: set_value(int(bool(state))))
+        elif widget_type == "combobox":
+            widget = QtWidgets.QComboBox()
+            policy = widget.sizePolicy()
+            policy.setHorizontalPolicy(QtWidgets.QSizePolicy.Expanding)
+            widget.setSizePolicy(policy)
+            widget.setSizeAdjustPolicy(QtWidgets.QComboBox.AdjustToMinimumContentsLengthWithIcon)
+            for key, value in widget_type_args[0].items():
+                widget.addItem(key, value)
+            widget.currentIndexChanged.connect(
+                lambda index: set_value(widget.itemData(index)))
+        else:
+            widget = QtWidgets.QLineEdit()
+            widget.setValidator(QtGui.QIntValidator(MIN_SIGNED_SHORT, MAX_SIGNED_SHORT))
+            widget.textChanged.connect(lambda text: set_value(int(text)))
+
+        layout.addLayout(self.create_labeled_widget(None, text, widget))
+
+        return widget
 
     def update_rotation(self, forwardedits, upedits, leftedits):
         rotation = self.bound_to.rotation
@@ -962,19 +990,18 @@ class ObjectEdit(DataEditor):
 
         self.objdatalabel = self.add_button_input(
             "Object-Specific Settings", "Reset to Default", self.fill_default_values)
-        self.userdata = []
-        for i in range(8):
-            self.userdata.append(
-                self.add_integer_input_index("Obj Data {0}".format(i+1), "userdata", i,
-                                             MIN_SIGNED_SHORT, MAX_SIGNED_SHORT)
-            )
+
+        self.userdata = [None] * 8
+        self.userdata_layout = QtWidgets.QVBoxLayout()
+        self.vbox.addLayout(self.userdata_layout)
 
         self.objectid.currentTextChanged.connect(self.update_name)
 
         for widget in self.position:
             widget.editingFinished.connect(self.catch_text_update)
 
-        self.objectid.currentTextChanged.connect(self.rename_object_parameters)
+        self.objectid.currentTextChanged.connect(self.rebuild_object_parameters_widgets)
+        self.objectid.currentText
 
         self.assets = self.add_label("Required Assets: Unknown")
         self.assets.setWordWrap(True)
@@ -982,35 +1009,33 @@ class ObjectEdit(DataEditor):
         hint.setVerticalPolicy(QtWidgets.QSizePolicy.Minimum)
         self.assets.setSizePolicy(hint)
 
-    def rename_object_parameters(self, current):
-        parameter_names, assets, tooltips, widget_types = load_parameter_names(current)
+    def rebuild_object_parameters_widgets(self, objectname):
+        for i in range(8):
+            self.userdata[i] = None
+        clear_layout(self.userdata_layout)
 
-        if parameter_names is None:
-            for i in range(8):
-                self.userdata[i][0].setText("Obj Data {0}".format(i+1))
-                self.userdata[i][0].setVisible(True)
-                self.userdata[i][1].setVisible(True)
-                self.userdata[i][1].setToolTip('')
-            self.assets.setText("Required Assets: Unknown")
+        parameter_names, assets, tooltips, widget_types = load_parameter_names(objectname)
+        tuples = zip(parameter_names, tooltips, widget_types)
+        for i, (parameter_name, tooltip, widget_type) in enumerate(tuples):
+            if parameter_name == "Unused":
+                if self.bound_to.userdata[i] != 0:
+                    Warning(f"Parameter with index {i} in object {objectname} is marked as Unused "
+                            f"but has value {self.bound_to.userdata[i]}")
+                continue
+
+            widget = self.add_types_widget_index(self.userdata_layout, parameter_name, 'userdata',
+                                                 i, widget_type)
+
+            widget.setToolTip(tooltips[i])
+
+            self.userdata[i] = widget
+
+        self.update_userdata_widgets(self.bound_to)
+
+        if not assets:
+            self.assets.setText("Required Assets: None")
         else:
-            for i in range(8):
-                if parameter_names[i] == "Unused":
-                    self.userdata[i][0].setVisible(False)
-                    self.userdata[i][1].setVisible(False)
-                    if self.bound_to.userdata[i] != 0:
-                        Warning("Parameter with index {0} in object {1} is marked as Unused but has value {2}".format(
-                            i, current, self.bound_to.userdata[i]
-                        ))
-                else:
-                    self.userdata[i][0].setVisible(True)
-                    self.userdata[i][1].setVisible(True)
-                    self.userdata[i][0].setText(parameter_names[i])
-                    self.userdata[i][1].setToolTip('')
-                    self.userdata[i][1].setToolTip(tooltips[i])
-            if len(assets) == 0:
-                self.assets.setText("Required Assets: None")
-            else:
-                self.assets.setText("Required Assets: {0}".format(", ".join(assets)))
+            self.assets.setText("Required Assets: {0}".format(", ".join(assets)))
 
     def update_name(self):
         if self.bound_to.widget is None:
@@ -1036,15 +1061,16 @@ class ObjectEdit(DataEditor):
         else:
             name = OBJECTNAMES[obj.objectid]
         index = self.objectid.findText(name)
-        self.objectid.setCurrentIndex(index)
+        with QtCore.QSignalBlocker(self.objectid):
+            self.objectid.setCurrentIndex(index)
 
         self.pathid.setText(str(obj.pathid))
         self.unk_2a.setText(str(obj.unk_2a))
         self.presence_filter.set_value(obj.presence_filter)
         self.presence.set_value(obj.presence)
         self.flag.setChecked(obj.unk_flag != 0)
-        for i in range(8):
-            self.userdata[i][1].setText(str(obj.userdata[i]))
+
+        self.rebuild_object_parameters_widgets(name)
 
     def fill_default_values(self):
         obj = self.bound_to
@@ -1052,9 +1078,21 @@ class ObjectEdit(DataEditor):
         if defaults is None:
             return
         obj.userdata = defaults.copy()
+        self.update_userdata_widgets(obj)
 
-        for i, (_label_widget, value_widget) in enumerate(self.userdata):
-            value_widget.setText(str(defaults[i]))
+    def update_userdata_widgets(self, obj):
+        for i, widget in enumerate(self.userdata):
+            if widget is None:
+                continue
+
+            with QtCore.QSignalBlocker(widget):
+                if isinstance(widget, QtWidgets.QCheckBox):
+                    widget.setChecked(bool(obj.userdata[i]))
+                elif isinstance(widget, QtWidgets.QComboBox):
+                    index = widget.findData(obj.userdata[i])
+                    widget.setCurrentIndex(index if index != -1 else 0)
+                elif isinstance(widget, QtWidgets.QLineEdit):
+                    widget.setText(str(obj.userdata[i]))
 
 
 class KartStartPointEdit(DataEditor):

--- a/widgets/data_editor.py
+++ b/widgets/data_editor.py
@@ -29,7 +29,10 @@ def load_parameter_names(objectname):
         tooltips = data.get("Tooltips", [])
         tooltips += [''] * (8 - len(tooltips))
 
-        return tuple(parameter_names), tuple(assets), tuple(tooltips)
+        widget_types = data.get("Widgets", [])
+        widget_types += [None] * (8 - len(widget_types))
+
+        return tuple(parameter_names), tuple(assets), tuple(tooltips), tuple(widget_types)
 
     except Exception as err:
         print(err)
@@ -980,7 +983,7 @@ class ObjectEdit(DataEditor):
         self.assets.setSizePolicy(hint)
 
     def rename_object_parameters(self, current):
-        parameter_names, assets, tooltips = load_parameter_names(current)
+        parameter_names, assets, tooltips, widget_types = load_parameter_names(current)
 
         if parameter_names is None:
             for i in range(8):


### PR DESCRIPTION
Object-specific fields (a.k.a. "user data")  can now define the widget type that best represents the set of values that the field accepts.

Supported types are:
- Text edits (default / fallback widget type as before)
- Check boxes
- Combo boxes

A number of object types have been updated with the new widget types. For example, for item boxes:
![image](https://github.com/RenolY2/mkdd-track-editor/assets/1853278/b7e322e9-ab1f-45b9-8458-c037b1d0e63b)
