### PR TITLE
Show required assets in its own read-only line edit.

### DIFF
--- a/widgets/data_editor.py
+++ b/widgets/data_editor.py
@@ -1003,11 +1003,9 @@ class ObjectEdit(DataEditor):
         self.objectid.currentTextChanged.connect(self.rebuild_object_parameters_widgets)
         self.objectid.currentText
 
-        self.assets = self.add_label("Required Assets: Unknown")
-        self.assets.setWordWrap(True)
-        hint = self.assets.sizePolicy()
-        hint.setVerticalPolicy(QtWidgets.QSizePolicy.Minimum)
-        self.assets.setSizePolicy(hint)
+        self.assets = QtWidgets.QLineEdit()
+        self.assets.setReadOnly(True)
+        self.vbox.addLayout(self.create_labeled_widget(self, 'Assets', self.assets))
 
     def rebuild_object_parameters_widgets(self, objectname):
         for i in range(8):
@@ -1032,10 +1030,10 @@ class ObjectEdit(DataEditor):
 
         self.update_userdata_widgets(self.bound_to)
 
-        if not assets:
-            self.assets.setText("Required Assets: None")
-        else:
-            self.assets.setText("Required Assets: {0}".format(", ".join(assets)))
+        self.assets.setText(', '.join(assets) if assets else 'None')
+        self.assets.setToolTip('Required Assets:\n\n' +
+                               '\n'.join(f'- {asset}' for asset in assets) if assets else 'None')
+        self.assets.setCursorPosition(0)
 
     def update_name(self):
         if self.bound_to.widget is None:

--- a/widgets/data_editor.py
+++ b/widgets/data_editor.py
@@ -1001,7 +1001,6 @@ class ObjectEdit(DataEditor):
             widget.editingFinished.connect(self.catch_text_update)
 
         self.objectid.currentTextChanged.connect(self.rebuild_object_parameters_widgets)
-        self.objectid.currentText
 
         self.assets = QtWidgets.QLineEdit()
         self.assets.setReadOnly(True)


### PR DESCRIPTION
- Asset list always take a single line of space.
- Clear distinction between label and content, and consistent with the rest of the form.
- User can copy/paste list of assets.
- Tool tip shows the asset list in a list layout.

| Before | After |
| --- | --- |
| ![image](https://github.com/RenolY2/mkdd-track-editor/assets/1853278/6b2adc3d-2d58-40e2-9a7f-e4420565455b) | ![image](https://github.com/RenolY2/mkdd-track-editor/assets/1853278/1ec90f16-7a1f-4cb0-9fb7-1b3d2edfa4ca) |