### PR TITLE
allow free (autogrounded) movement in 3d mode

### DIFF
--- a/editor_controls.py
+++ b/editor_controls.py
@@ -418,6 +418,16 @@ class Gizmo3DMoveZ(Gizmo3DMoveX):
         return 0, 0, delta
 
 
+class Gizmo3DMove(Gizmo3DMoveX):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.axis_name = "middle"
+
+    def move(self, editor, buttons, event):
+        if editor.gizmo.was_hit["middle"]:
+            coords = editor.get_3d_coordinates(event.x(), event.y())
+            editor.move_points_to.emit(coords.x, coords.y, coords.z)
+
 class Gizmo3DRotateY(Gizmo2DRotateY):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -537,6 +547,7 @@ class UserControl(object):
         self.add_action3d(Gizmo3DMoveX("Gizmo3DMoveX", "Left"))
         self.add_action3d(Gizmo3DMoveY("Gizmo3DMoveY", "Left"))
         self.add_action3d(Gizmo3DMoveZ("Gizmo3DMoveZ", "Left"))
+        self.add_action3d(Gizmo3DMove("Gizmo3DMove", "Left"))
         self.add_action3d(Gizmo3DRotateX("Gizmo3DRotateX", "Left"))
         self.add_action3d(Gizmo3DRotateY("Gizmo3DRotateY", "Left"))
         self.add_action3d(Gizmo3DRotateZ("Gizmo3DRotateZ", "Left"))
@@ -641,6 +652,10 @@ class UserControl(object):
 
     def handle_move_3d(self, event):
         editor = self._editor_widget
+
+        place_at = editor.get_3d_coordinates(event.x(), event.y())
+        if place_at is not None:
+            editor.position_update.emit(event, (round(place_at.x, 2), round(place_at.z, 2), round(-place_at.y, 2)))
 
         for key in key_enums.keys():
             if self.buttons.is_held(event, key):

--- a/gizmo.py
+++ b/gizmo.py
@@ -93,7 +93,7 @@ class Gizmo(Model):
                 if is3d: named_meshes["rotation_x"].render_colorid(0x4)
                 named_meshes["rotation_y"].render_colorid(0x5)
                 if is3d: named_meshes["rotation_z"].render_colorid(0x6)
-            if not is3d: named_meshes["middle"].render_colorid(0x7)
+            named_meshes["middle"].render_colorid(0x7)
             glPopMatrix()
 
     def register_callback(self, gizmopart, func):
@@ -152,7 +152,7 @@ class Gizmo(Model):
                 glColor4f(*Z_COLOR if hover_id != 0x6 else HOVER_COLOR)
                 self.named_meshes["rotation_z"].render()
 
-        if not is3d and (not handle_hit or self.was_hit["middle"]):
+        if not handle_hit or self.was_hit["middle"]:
             glColor4f(*MIDDLE_COLOR if hover_id != 0x7 else HOVER_COLOR)
             self.named_meshes["middle"].render()
 

--- a/mkdd_editor.py
+++ b/mkdd_editor.py
@@ -35,6 +35,7 @@ from lib.dolreader import DolFile, read_float, write_float, read_load_immediate_
 from widgets.file_select import FileSelect
 from lib.bmd_render import clear_temp_folder, load_textured_bmd
 from lib.game_visualizer import Game
+from lib.vectors import Vector3
 PIKMIN2GEN = "Generator files (defaultgen.txt;initgen.txt;plantsgen.txt;*.txt)"
 
 
@@ -1317,6 +1318,7 @@ class GenEditor(QtWidgets.QMainWindow):
             lambda _checked: self.button_open_add_item_window())
         #self.pik_control.button_move_object.pressed.connect(self.button_move_objects)
         self.level_view.move_points.connect(self.action_move_objects)
+        self.level_view.move_points_to.connect(self.action_move_objects_to)
         self.level_view.height_update.connect(self.action_change_object_heights)
         self.level_view.create_waypoint.connect(self.action_add_object)
         self.level_view.create_waypoint_3d.connect(self.action_add_object_3d)
@@ -2315,6 +2317,23 @@ class GenEditor(QtWidgets.QMainWindow):
         self.pik_control.update_info()
         self.set_has_unsaved_changes(True)
 
+    @catch_exception
+    def action_move_objects_to(self, posx, posy, posz):
+        self.level_view.gizmo.move_to_average(self.level_view.selected_positions,
+                                              self.level_view.selected_rotations)
+        orig_avg = self.level_view.gizmo.position.copy()
+        new_avg = Vector3(posx, posz, -posy)
+        diff = new_avg - orig_avg
+        for pos in self.level_view.selected_positions:
+            pos.x = pos.x + diff.x
+            pos.y = pos.y + diff.y
+            pos.z = pos.z + diff.z
+
+            self.level_view.gizmo.move_to_average(self.level_view.selected_positions,
+                                                  self.level_view.selected_rotations)
+        self.level_view.do_redraw()
+        self.pik_control.update_info()
+        self.set_has_unsaved_changes(True)
 
     @catch_exception
     def action_change_object_heights(self, deltay):

--- a/mkdd_widgets.py
+++ b/mkdd_widgets.py
@@ -80,6 +80,7 @@ class BolMapViewer(QtOpenGLWidgets.QOpenGLWidget):
     height_update = QtCore.Signal(float)
     select_update = QtCore.Signal()
     move_points = QtCore.Signal(float, float, float)
+    move_points_to = QtCore.Signal(float, float, float)
     connect_update = QtCore.Signal(int, int)
     create_waypoint = QtCore.Signal(float, float)
     create_waypoint_3d = QtCore.Signal(float, float, float)
@@ -1476,6 +1477,22 @@ class BolMapViewer(QtOpenGLWidgets.QOpenGLWidget):
             dir.z = tmp
 
         return Line(pos, dir)
+
+    def get_3d_coordinates(self, mousex, mousey):
+        ray = self.create_ray_from_mouseclick(mousex, mousey)
+        pos = None
+
+        if self.collision is not None:
+            pos = self.collision.collide_ray(ray)
+
+        if pos is None:
+            plane = Plane.xy_aligned(Vector3(0.0, 0.0, 0.0))
+
+            collision = ray.collide_plane(plane)
+            if collision is not False:
+                pos, _ = collision
+
+        return pos
 
 
 def create_object_type_pixmap(canvas_size: int, directed: bool,


### PR DESCRIPTION
When using the center of the gizmo in 3d mode, the points will move around that. There is some autogrounded movement due to limitations of the viewer. 
Addresses #55. 