### PR TITLE
Revised object creation.

### DIFF
--- a/mkdd_editor.py
+++ b/mkdd_editor.py
@@ -2162,11 +2162,11 @@ class GenEditor(QtWidgets.QMainWindow):
         self.level_view.set_mouse_mode(mkdd_widgets.MOUSE_MODE_NONE)
         self.object_to_be_added = None
 
+        object_to_select = None
+
         if option == "add_enemypath":
             self.level_file.enemypointgroups.add_group()
-            self.level_view.selected = [self.level_file.enemypointgroups.groups[-1]]
-            self.level_view.selected_positions = []
-            self.level_view.selected_rotations = []
+            object_to_select = self.level_file.enemypointgroups.groups[-1]
         elif option == "add_enemypoints":
             if isinstance(obj, libbol.EnemyPointGroup):
                 group_id = obj.id
@@ -2181,9 +2181,7 @@ class GenEditor(QtWidgets.QMainWindow):
 
         elif option == "add_checkpointgroup":
             self.level_file.checkpoints.add_group()
-            self.level_view.selected = [self.level_file.checkpoints.groups[-1]]
-            self.level_view.selected_positions = []
-            self.level_view.selected_rotations = []
+            object_to_select = self.level_file.checkpoints.groups[-1]
         elif option == "add_checkpoints":
             if isinstance(obj, libbol.CheckpointGroup):
                 group_id = obj.grouplink
@@ -2195,6 +2193,7 @@ class GenEditor(QtWidgets.QMainWindow):
             self.level_view.set_mouse_mode(mkdd_widgets.MOUSE_MODE_ADDWP)
         elif option == "add_route":
             self.level_file.routes.append(libbol.Route.new())
+            object_to_select = self.level_file.routes[-1]
         elif option == "add_routepoints":
             if isinstance(obj, libbol.Route):
                 group_id = self.level_file.routes.index(obj)
@@ -2235,6 +2234,9 @@ class GenEditor(QtWidgets.QMainWindow):
 
 
         self.leveldatatreeview.set_objects(self.level_file)
+
+        if object_to_select is not None:
+            self.select_tree_item_bound_to(object_to_select)
 
     @catch_exception
     def action_move_objects(self, deltax, deltay, deltaz):

--- a/mkdd_editor.py
+++ b/mkdd_editor.py
@@ -2074,15 +2074,17 @@ class GenEditor(QtWidgets.QMainWindow):
                     self.level_file.checkpoints.groups.append(libbol.CheckpointGroup.new())
                 insertion_index = position
                 # If a selection exists, use it as reference for the insertion point.
-                selected_items = self.leveldatatreeview.selectedItems()
-                if selected_items:
-                    selected_item = selected_items[-1]
+                for selected_item in reversed(self.leveldatatreeview.selectedItems()):
+                    if not hasattr(selected_item, 'bound_to'):
+                        continue
                     if isinstance(selected_item.bound_to, libbol.Checkpoint):
                         group = selected_item.parent().get_index_in_parent()
                         insertion_index = selected_item.get_index_in_parent() + 1
-                    elif isinstance(selected_item.bound_to, libbol.CheckpointGroup):
+                        break
+                    if isinstance(selected_item.bound_to, libbol.CheckpointGroup):
                         group = selected_item.get_index_in_parent()
                         insertion_index = 0
+                        break
 
                 self.level_file.checkpoints.groups[group].points.insert(
                     insertion_index, placeobject)
@@ -2107,15 +2109,17 @@ class GenEditor(QtWidgets.QMainWindow):
                 placeobject.group = group
                 insertion_index = position
                 # If a selection exists, use it as reference for the insertion point.
-                selected_items = self.leveldatatreeview.selectedItems()
-                if selected_items:
-                    selected_item = selected_items[-1]
+                for selected_item in reversed(self.leveldatatreeview.selectedItems()):
+                    if not hasattr(selected_item, 'bound_to'):
+                        continue
                     if isinstance(selected_item.bound_to, libbol.EnemyPoint):
                         placeobject.group = selected_item.parent().get_index_in_parent()
                         insertion_index = selected_item.get_index_in_parent() + 1
-                    elif isinstance(selected_item.bound_to, libbol.EnemyPointGroup):
+                        break
+                    if isinstance(selected_item.bound_to, libbol.EnemyPointGroup):
                         placeobject.group = selected_item.get_index_in_parent()
                         insertion_index = 0
+                        break
                 self.level_file.enemypointgroups.groups[placeobject.group].points.insert(
                     insertion_index, placeobject)
             elif isinstance(object, libbol.RoutePoint):
@@ -2124,15 +2128,17 @@ class GenEditor(QtWidgets.QMainWindow):
                     self.level_file.routes.append(libbol.Route.new())
                 insertion_index = position
                 # If a selection exists, use it as reference for the insertion point.
-                selected_items = self.leveldatatreeview.selectedItems()
-                if selected_items:
-                    selected_item = selected_items[-1]
+                for selected_item in reversed(self.leveldatatreeview.selectedItems()):
+                    if not hasattr(selected_item, 'bound_to'):
+                        continue
                     if isinstance(selected_item.bound_to, libbol.RoutePoint):
                         group = selected_item.parent().get_index_in_parent()
                         insertion_index = selected_item.get_index_in_parent() + 1
-                    elif isinstance(selected_item.bound_to, libbol.Route):
+                        break
+                    if isinstance(selected_item.bound_to, libbol.Route):
                         group = selected_item.get_index_in_parent()
                         insertion_index = 0
+                        break
                 self.level_file.routes[group].points.insert(insertion_index, placeobject)
             elif isinstance(object, libbol.MapObject):
                 self.level_file.objects.objects.append(placeobject)


### PR DESCRIPTION
Two minor improvements or corrections:

- Group-like containers (enemy paths, checkpoint groups, and routes) are now automatically selected in the tree view and expanded upon creation.
- Changing the currently selected item while inserting objects of a given type no longer causes an exception (missing `bound_to` attribute), or causes the new object to be inserted at a wrong index.