### PR TITLE
Avoid over-updating data editor on new selections.

### DIFF
--- a/mkdd_editor.py
+++ b/mkdd_editor.py
@@ -531,7 +531,7 @@ class GenEditor(QtWidgets.QMainWindow):
         self.level_view.gizmo.move_to_average(self.level_view.selected_positions,
                                               self.level_view.selected_rotations)
         self.level_view.do_redraw()
-        self.level_view.select_update.emit()
+        self.action_update_info()
 
     def setup_ui(self):
         self.resize(1000, 800)
@@ -1288,8 +1288,6 @@ class GenEditor(QtWidgets.QMainWindow):
         pass
 
     def connect_actions(self):
-        self.level_view.select_update.connect(self.action_update_info)
-        self.level_view.select_update.connect(self.select_from_3d_to_treeview)
         #self.pik_control.lineedit_coordinatex.textChanged.connect(self.create_field_edit_action("coordinatex"))
         #self.pik_control.lineedit_coordinatey.textChanged.connect(self.create_field_edit_action("coordinatey"))
         #self.pik_control.lineedit_coordinatez.textChanged.connect(self.create_field_edit_action("coordinatez"))
@@ -2602,10 +2600,10 @@ class GenEditor(QtWidgets.QMainWindow):
 
     def select_from_3d_to_treeview(self):
         if self.level_file is not None:
+            item = None
             selected = self.level_view.selected
             if len(selected) == 1:
                 currentobj = selected[0]
-                item = None
                 if isinstance(currentobj, libbol.EnemyPoint):
                     for i in range(self.leveldatatreeview.enemyroutes.childCount()):
                         child = self.leveldatatreeview.enemyroutes.child(i)
@@ -2655,6 +2653,11 @@ class GenEditor(QtWidgets.QMainWindow):
 
                 if suppress_signal:
                     self.leveldatatreeview.blockSignals(False)
+
+            if item is None:
+                # If no item was selected, no tree item will be selected, and the data editor needs
+                # to be updated manually.
+                self.action_update_info()
 
             #if nothing is selected and the currentitem is something that can be selected
             #clear out the buttons

--- a/mkdd_widgets.py
+++ b/mkdd_widgets.py
@@ -75,7 +75,6 @@ class BolMapViewer(QtOpenGLWidgets.QOpenGLWidget):
     mouse_released = QtCore.Signal(QtGui.QMouseEvent)
     mouse_wheel = QtCore.Signal(QtGui.QWheelEvent)
     position_update = QtCore.Signal(QtGui.QMouseEvent, tuple)
-    select_update = QtCore.Signal()
     move_points = QtCore.Signal(float, float, float)
     move_points_to = QtCore.Signal(float, float, float)
     connect_update = QtCore.Signal(int, int)
@@ -922,7 +921,7 @@ class BolMapViewer(QtOpenGLWidgets.QOpenGLWidget):
                     if obj in selected_set:
                         self.selected.append(obj)
 
-                self.select_update.emit()
+                self.editor.select_from_3d_to_treeview()
 
                 self.gizmo.move_to_average(self.selected_positions, self.selected_rotations)
                 if len(selected) == 0:


### PR DESCRIPTION
When a user clicked on an object in the viewport, a series of events were emitted, resulting in updating the data editor twice:
- One update as a direct reaction to the selection of the underlying object
- Another one after the associated tree item was selected

The `select_update` signal has been removed, and updates are now explicitly invoked.

In slower systems, the update time should feel marginally snappier; no other behavior change expected.