### PR TITLE
Trivial performance improvements in `Line.collide()`.

### DIFF
--- a/lib/collision.py
+++ b/lib/collision.py
@@ -121,7 +121,9 @@ class Collision(object):
             x, y, z = verts[v3i[0]-1]
             v3 = Vector3(x, -z, y)
 
-            self.triangles.append(Triangle(v1,v2,v3))
+            triangle = Triangle(v1, v2, v3)
+            if not triangle.normal.is_zero():
+                self.triangles.append(triangle)
 
         self.cell_size = 2000
 

--- a/lib/vectors.py
+++ b/lib/vectors.py
@@ -167,6 +167,8 @@ class Triangle(object):
         self.p3 = p3
         self.p1_to_p2 = p2 - p1
         self.p1_to_p3 = p3 - p1
+        self.p2_to_p3 = p3 - p2
+        self.p3_to_p1 = p1 - p3
 
         self.normal = self.p1_to_p2.cross(self.p1_to_p3)
 
@@ -186,27 +188,23 @@ class Line(object):
     def collide(self, tri: Triangle):
         normal = tri.normal
 
-        if normal.dot(self.direction) == 0:
+        dot = normal.dot(self.direction)
+        if dot == 0.0:
             return False
 
-        d = ((tri.origin - self.origin).dot(normal)) / normal.dot(self.direction)
+        d = (tri.origin - self.origin).dot(normal) / dot
 
         if d < 0:
             return False
 
         intersection_point = self.origin + self.direction * d
 
-        # return intersection_point
         C0 = intersection_point - tri.origin
-
         if normal.dot(tri.p1_to_p2.cross(C0)) > 0:
-            p2_to_p3 = tri.p3 - tri.p2
             C1 = intersection_point - tri.p2
-
-            if normal.dot(p2_to_p3.cross(C1)) > 0:
-                p3_to_p1 = tri.origin - tri.p3
+            if normal.dot(tri.p2_to_p3.cross(C1)) > 0:
                 C2 = intersection_point - tri.p3
-                if normal.dot(p3_to_p1.cross(C2)) > 0:
+                if normal.dot(tri.p3_to_p1.cross(C2)) > 0:
                     return intersection_point, d
 
         return False

--- a/lib/vectors.py
+++ b/lib/vectors.py
@@ -208,12 +208,8 @@ class Line(object):
                 C2 = intersection_point - tri.p3
                 if normal.dot(p3_to_p1.cross(C2)) > 0:
                     return intersection_point, d
-                else:
-                    return False
-            else:
-                return False
-        else:
-            return False
+
+        return False
 
     def collide_py(self, tri: Triangle):
         hit = False

--- a/lib/vectors.py
+++ b/lib/vectors.py
@@ -188,7 +188,7 @@ class Line(object):
         if normal.is_zero():
             return False
 
-        if tri.normal.dot(self.direction) == 0:
+        if normal.dot(self.direction) == 0:
             return False
 
         d = ((tri.origin - self.origin).dot(normal)) / normal.dot(self.direction)
@@ -201,14 +201,14 @@ class Line(object):
         # return intersection_point
         C0 = intersection_point - tri.origin
 
-        if tri.normal.dot(tri.p1_to_p2.cross(C0)) > 0:
+        if normal.dot(tri.p1_to_p2.cross(C0)) > 0:
             p2_to_p3 = tri.p3 - tri.p2
             C1 = intersection_point - tri.p2
 
-            if tri.normal.dot(p2_to_p3.cross(C1)) > 0:
+            if normal.dot(p2_to_p3.cross(C1)) > 0:
                 p3_to_p1 = tri.origin - tri.p3
                 C2 = intersection_point - tri.p3
-                if tri.normal.dot(p3_to_p1.cross(C2)) > 0:
+                if normal.dot(p3_to_p1.cross(C2)) > 0:
                     return intersection_point, d
                 else:
                     return False

--- a/lib/vectors.py
+++ b/lib/vectors.py
@@ -185,8 +185,6 @@ class Line(object):
 
     def collide(self, tri: Triangle):
         normal = tri.normal
-        if normal.is_zero():
-            return False
 
         if normal.dot(self.direction) == 0:
             return False


### PR DESCRIPTION
With a BCO file loaded with 10119 triangles, `Collision.collide_ray()` goes from `0.047 secs` to `0.038 secs` on average (average of 100 calls).