### PR TITLE
Implement X-ray selection in the viewport.

### DIFF
--- a/editor_controls.py
+++ b/editor_controls.py
@@ -122,11 +122,6 @@ class TopdownSelect(ClickDragAction):
         editor.selectionbox_start = (selectstartx, selectstartz)
         editor.selectionbox_end = None
 
-        if editor.level_file is not None:
-            editor.selectionqueue.queue_selection(x, y, 1, 1,
-                                           editor.shift_is_pressed)
-            editor.do_redraw(force=True)
-
     def move(self, editor, buttons, event):
         selectendx, selectendz = editor.mouse_coord_to_world_coord(event.x(), event.y())
         editor.selectionbox_end = (selectendx, selectendz)
@@ -153,6 +148,11 @@ class TopdownSelect(ClickDragAction):
 class Gizmo2DMoveX(ClickDragAction):
     def just_clicked(self, editor, buttons, event):
         super().just_clicked(editor, buttons, event)
+
+        # Generally, selection tasks should be scheduled with the click release event, however, for
+        # the gizmo, we want the first press event to already make the gizmo handle interactive.
+        # Therefore, the event is scheduled on the press event (instead of in the natural release
+        # event).
         editor.selectionqueue.queue_selection(event.x(), event.y(), 1, 1,
                                               editor.shift_is_pressed, do_gizmo=True)
         editor.do_redraw(force=True)
@@ -288,12 +288,6 @@ class Select3D(ClickDragAction):
 
     def just_clicked(self, editor, buttons, event):
         super().just_clicked(editor, buttons, event)
-        editor.selectionqueue.queue_selection(
-            event.x(), event.y(), 1, 1,
-            editor.shift_is_pressed)
-        #print("WE HAVE SENT A REQUEST")
-        editor.do_redraw(force=True)
-
 
         editor.camera_direction.normalize()
 
@@ -576,7 +570,6 @@ class UserControl(object):
         else:
             self.handle_release_3d(event)
 
-        editor.selectionqueue.clear()
         editor.gizmo.reset_hit_status()
         #print("Gizmo hit status was reset!!!!", editor.gizmo.was_hit_at_all)
         editor.do_redraw()

--- a/lib/game_visualizer.py
+++ b/lib/game_visualizer.py
@@ -126,11 +126,13 @@ class Game(object):
                 renderer.models.render_player_position_colored(self.kart_targets[p], False, p)
             p += 1
 
-    def render_collision(self, renderer: BolMapViewer, objlist, objselectioncls):
+    def render_collision(self, renderer: BolMapViewer, objlist, objselectioncls, selected):
         if self.dolphin.initialized():
             idbase = 0x100000
             offset = len(objlist)
             for ptr, pos in self.karts:
+                if ptr in selected:
+                    continue
                 objlist.append(objselectioncls(
                     obj=ptr,
                     pos1=pos,

--- a/mkdd_editor.py
+++ b/mkdd_editor.py
@@ -2237,11 +2237,6 @@ class GenEditor(QtWidgets.QMainWindow):
 
     @catch_exception
     def action_move_objects(self, deltax, deltay, deltaz):
-        for i in range(len(self.level_view.selected_positions)):
-            for j in range(len(self.level_view.selected_positions)):
-                pos = self.level_view.selected_positions
-                if i != j and pos[i] == pos[j]:
-                    print("What the fuck")
         for pos in self.level_view.selected_positions:
             """obj.x += deltax
             obj.z += deltaz


### PR DESCRIPTION
Previously, only the top-most object of a number of overlapping objects would be selected.

Now, the marquee selection has been revampped so that it selects all objects. The mechanism consists of applying multiple pick iterations, hiding selected objects after each iteration, until no new object is selected.

Test plan:
- Add an object of any type (e.g. a respawn point).
- Select the object, and copy and paste it several times at the same position.
- With a marquee selection, attempt to select all objects.
- Verify that all overlapping objects have been selected (the data editor should show the number of selected objects).