### PR TITLE
Fix regression in framing functionality.

### DIFF
--- a/mkdd_editor.py
+++ b/mkdd_editor.py
@@ -432,13 +432,13 @@ class GenEditor(QtWidgets.QMainWindow):
 
         if visible_objectroutes or visible_cameraroutes or visible_unassignedroutes:
             camera_routes = set(camera.route for camera in self.level_file.cameras)
-            object_routes = set(obj.pathid for obj in self.level_file.objects.objects)
+            object_routes = set(obj.route for obj in self.level_file.objects.objects)
             assigned_routes = camera_routes.union(object_routes)
 
-            for i, object_route in enumerate(self.level_file.routes):
-                if (not ((i in object_routes and visible_objectroutes) or
-                         (i in camera_routes and visible_cameraroutes) or
-                         (i not in assigned_routes and visible_unassignedroutes))):
+            for object_route in self.level_file.routes:
+                if (not ((object_route in object_routes and visible_objectroutes) or
+                         (object_route in camera_routes and visible_cameraroutes) or
+                         (object_route not in assigned_routes and visible_unassignedroutes))):
                     continue
                 for object_route_point in object_route.points:
                     extend(object_route_point.position)
@@ -2223,7 +2223,7 @@ class GenEditor(QtWidgets.QMainWindow):
             self.action_ground_objects((new_point_1.position, new_point_2.position))
 
             self.level_file.routes.append(new_route)
-            obj.pathid = len(self.level_file.routes) - 1
+            obj.route = self.level_file.routes[-1]
         elif option == "add_respawn":
             self.object_to_be_added = [libbol.JugemPoint.new(), -1, 0]
             self.pik_control.button_add_object.setChecked(True)

--- a/mkdd_widgets.py
+++ b/mkdd_widgets.py
@@ -502,6 +502,7 @@ class BolMapViewer(QtOpenGLWidgets.QOpenGLWidget):
 
     def clear_collision(self):
         self.alternative_mesh = None
+        self.collision = None
 
         if self.main_model is not None:
             glDeleteLists(self.main_model, 1)


### PR DESCRIPTION
`pathid` (`int`) in objects was changed to `route` (`object`) as part of 016f5885dca197b9fbef86b0e64d5e2aa7e31f57.

However, there were some leftovers that broke the framing functionality.