### PR TITLE
Prevent exception in object-specific fields.

### DIFF
--- a/widgets/data_editor.py
+++ b/widgets/data_editor.py
@@ -532,7 +532,7 @@ class DataEditor(QtWidgets.QWidget):
         else:
             widget = QtWidgets.QLineEdit()
             widget.setValidator(QtGui.QIntValidator(MIN_SIGNED_SHORT, MAX_SIGNED_SHORT))
-            widget.textChanged.connect(lambda text: set_value(int(text)))
+            widget.textChanged.connect(lambda text: set_value(int(text) if text else 0))
 
         layout.addLayout(self.create_labeled_widget(None, text, widget))
 


### PR DESCRIPTION
When numeric object-specific fields were left empty, the following exception was raised:

```
Traceback (most recent call last):
  File "/w/mkdd-track-editor/widgets/data_editor.py", line 535, in <lambda>
    widget.textChanged.connect(lambda text: set_value(int(text)))
ValueError: invalid literal for int() with base 10: ''
```