### PR TITLE
Show correct next enemy point in Dolphin hook.

### DIFF
--- a/lib/game_visualizer.py
+++ b/lib/game_visualizer.py
@@ -166,12 +166,14 @@ class Game(object):
                         self.kart_headings[i].y = self.dolphin.read_float(kartPtr + 0x30C)
                         self.kart_headings[i].z = self.dolphin.read_float(kartPtr + 0x310)
 
-                        karttarget = self.dolphin.read_uint32(kartctrlPtr + 0x1C0 + i*4)
+                        # This is equivalent to KartCtrl::getKartEnemy() (NTSC-U).
+                        karttarget = self.dolphin.read_uint32(kartctrlPtr + 0x180 + i * 4)
 
                         if self.dolphin.address_valid(karttarget):
-                            clpoint = self.dolphin.read_uint32(karttarget)
+                            # 0x3C offset seen at 0x80235c1c (NTSC-U).
+                            clpoint = self.dolphin.read_uint32(karttarget + 0x3C)
                             if self.dolphin.address_valid(clpoint):
-                                vec3ptr = self.dolphin.read_uint32(clpoint+4)
+                                vec3ptr = clpoint + 0x28  # 0x28 offset seen at 0x802438fc (NTSC-U).
                                 if self.dolphin.address_valid(vec3ptr):
                                     self.kart_targets[i].x = self.dolphin.read_float(vec3ptr)
                                     self.kart_targets[i].y = self.dolphin.read_float(vec3ptr+4)


### PR DESCRIPTION
A number of offsets have been tweaked to load the position array from the correct address. Address to the relevant data structure is now retrieved using `KartCtrl::getKartEnemy()` as reference.

Previously, a different function was used (`KartCtrl::GetKartCenterPtr()`, whose definition is just below `KartCtrl::getKartEnemy()` in NTSC-U), but the positions shown in the Editor did not match the next enemy point; some other data was being represented [which is yet to be determined].

**Before the fix**, the *supposed* next enemy points can be drawn behind the kart's position:

![MKDD Track Editor - Next enemy points in Dolphin hook (before fix)](https://github.com/RenolY2/mkdd-track-editor/assets/1853278/4e6d4034-8f9b-4568-b9d2-f159f4e92653)

**After the fix**, next enemy points are always drawn ahead of the kart, and are reliably updated as soon as karts reach the enemy point (i.e. as soon as karts *touch* the enemy points' spheres):

![MKDD Track Editor - Next enemy points in Dolphin hook (after fix)](https://github.com/RenolY2/mkdd-track-editor/assets/1853278/753c9573-7421-424b-bc7b-5f7f3a0e112d)

NOTE: Clips taken on a modified Baby Park with fewer enemy points for simplicity.