### PR TITLE
Update viewport when object's route changes.

### DIFF
--- a/widgets/data_editor.py
+++ b/widgets/data_editor.py
@@ -992,6 +992,7 @@ class ObjectEdit(DataEditor):
             routes["Route {0}".format(i)] = route
 
         self.route = self.add_dropdown_input("Route", "route", routes)
+        self.route.currentIndexChanged.connect(self.catch_text_update)
         set_tool_tip(self.route, ttl.objectdata['Route ID'])
 
         self.unk_2a = self.add_integer_input("Route Point ID", "unk_2a",


### PR DESCRIPTION
Routes can change their representation depending on which objects and cameras have been assigned to. Since 016f5885dc, the viewport was not being updated when an object's route changed, leaving the viewport potentially dirty until the mouse was moved over the viewport.