### PR TITLE
Bouquet of fixes for object-specific fields.

### DIFF
--- a/object_parameters/TMapObjFireCircle.json
+++ b/object_parameters/TMapObjFireCircle.json
@@ -3,7 +3,7 @@
         "Number of Fire Balls",
         "Unknown 2",
         "Unknown 3",
-        "Unused",
+        "Unknown 4",
         "Unused",
         "Unused",
         "Unused",

--- a/object_parameters/TMapObjKpFireBar.json
+++ b/object_parameters/TMapObjKpFireBar.json
@@ -4,7 +4,7 @@
         "Unknown 2",
         "Unknown 3",
         "Unknown 4",
-        "Unused",
+        "Unknown 5",
         "Unused",
         "Unused",
         "Unused"

--- a/object_parameters/TMapObjMoveItemBox.json
+++ b/object_parameters/TMapObjMoveItemBox.json
@@ -7,7 +7,7 @@
         "Unused",
         "Unused",
         "Unused",
-        "Unused"
+        "Unknown"
     ],
     "Assets": [],
     "Tooltips": [

--- a/object_parameters/TMapObjSandPillar.json
+++ b/object_parameters/TMapObjSandPillar.json
@@ -1,7 +1,7 @@
 {
     "Object Parameters": [
         "Unknown 1",
-        "Unused",
+        "Unknown 2",
         "Unknown 3",
         "Unused",
         "Unused",

--- a/object_parameters/TSMABoidBirdManager.json
+++ b/object_parameters/TSMABoidBirdManager.json
@@ -2,7 +2,7 @@
     "Object Parameters": [
         "Number of Birds",
         "Unknown 2",
-        "Unused",
+        "Unknown 3",
         "Unused",
         "Unused",
         "Unused",

--- a/widgets/data_editor.py
+++ b/widgets/data_editor.py
@@ -530,9 +530,12 @@ class DataEditor(QtWidgets.QWidget):
             widget.currentIndexChanged.connect(
                 lambda index: set_value(widget.itemData(index)))
         else:
-            widget = QtWidgets.QLineEdit()
-            widget.setValidator(QtGui.QIntValidator(MIN_SIGNED_SHORT, MAX_SIGNED_SHORT))
-            widget.textChanged.connect(lambda text: set_value(int(text) if text else 0))
+            widget = QtWidgets.QSpinBox()
+            policy = widget.sizePolicy()
+            policy.setHorizontalPolicy(QtWidgets.QSizePolicy.Expanding)
+            widget.setSizePolicy(policy)
+            widget.setRange(MIN_SIGNED_SHORT, MAX_SIGNED_SHORT)
+            widget.valueChanged.connect(set_value)
 
         layout.addLayout(self.create_labeled_widget(None, text, widget))
 
@@ -1134,8 +1137,8 @@ class ObjectEdit(DataEditor):
                 elif isinstance(widget, QtWidgets.QComboBox):
                     index = widget.findData(obj.userdata[i])
                     widget.setCurrentIndex(index if index != -1 else 0)
-                elif isinstance(widget, QtWidgets.QLineEdit):
-                    widget.setText(str(obj.userdata[i]))
+                elif isinstance(widget, QtWidgets.QSpinBox):
+                    widget.setValue(obj.userdata[i])
 
 
 class KartStartPointEdit(DataEditor):

--- a/widgets/data_editor.py
+++ b/widgets/data_editor.py
@@ -1054,14 +1054,14 @@ class ObjectEdit(DataEditor):
         for i, (parameter_name, tooltip, widget_type) in enumerate(tuples):
             if parameter_name == "Unused":
                 if self.bound_to.userdata[i] != 0:
-                    print(f"Parameter with index {i} in object {objectname} is marked as Unused "
-                          f"but has value {self.bound_to.userdata[i]}")
+                    print(f"Warning: Parameter with index {i} in object {objectname} is marked as "
+                          f"unused but has value {self.bound_to.userdata[i]}.")
                 continue
 
             widget = self.add_types_widget_index(self.userdata_layout, parameter_name, 'userdata',
                                                  i, widget_type)
 
-            set_tool_tip(widget, tooltips[i])
+            set_tool_tip(widget, tooltip)
 
             self.userdata[i] = widget
 

--- a/widgets/data_editor.py
+++ b/widgets/data_editor.py
@@ -405,7 +405,7 @@ class DataEditor(QtWidgets.QWidget):
 
         layout = self.create_labeled_widget(self, labeltext, button)
         self.vbox.addLayout(layout)
-        return button
+        return layout
 
     def add_color_input(self, text, attribute, with_alpha=False):
         line_edits = []
@@ -1022,7 +1022,7 @@ class ObjectEdit(DataEditor):
                                       off_value=0, on_value=1)
         set_tool_tip(self.flag, ttl.objectdata['Collision'])
 
-        self.objdatalabel = self.add_button_input(
+        self.objdata_reset_button_layout = self.add_button_input(
             "Object-Specific Settings", "Reset to Default", self.fill_default_values)
 
         self.userdata = [None] * 8
@@ -1064,6 +1064,13 @@ class ObjectEdit(DataEditor):
             set_tool_tip(widget, tooltips[i])
 
             self.userdata[i] = widget
+
+        # Only show reset button if there is any object-specific field that can be reset.
+        has_fields = any(widget is not None for widget in self.userdata)
+        for i in range(self.objdata_reset_button_layout.count()):
+            item = self.objdata_reset_button_layout.itemAt(i)
+            if item_widget := item.widget():
+                item_widget.setVisible(has_fields)
 
         self.update_userdata_widgets(self.bound_to)
 

--- a/widgets/data_editor.py
+++ b/widgets/data_editor.py
@@ -1054,8 +1054,8 @@ class ObjectEdit(DataEditor):
         for i, (parameter_name, tooltip, widget_type) in enumerate(tuples):
             if parameter_name == "Unused":
                 if self.bound_to.userdata[i] != 0:
-                    Warning(f"Parameter with index {i} in object {objectname} is marked as Unused "
-                            f"but has value {self.bound_to.userdata[i]}")
+                    print(f"Parameter with index {i} in object {objectname} is marked as Unused "
+                          f"but has value {self.bound_to.userdata[i]}")
                 continue
 
             widget = self.add_types_widget_index(self.userdata_layout, parameter_name, 'userdata',


### PR DESCRIPTION
- A spinbox for fields that do not specify a custom widget type (e.g. checkbox or combobox). Previously, a text edit with a integer validator was used, but wrong values could still be entered, causing exceptions when saving the BOL document.
- **Reset to Default** is now only shown if there is at least one object-specific field.
- Addressed some linter warnings.
- Re-enabled a warning message that alerts about "unused" fields that have non-zero values.
- Changed some "unused" values to "unknown", as it turned out there were in fact some object types with "unused" fields that are actually used.