### PR TITLE
Relax ray and triangle collision to accept hits on edges.

### DIFF
--- a/lib/collision.py
+++ b/lib/collision.py
@@ -216,11 +216,11 @@ def _collide_ray_and_triangle(
     intersection_point = x + dx * d, y + dy * d, z + dz * d
 
     C0 = intersection_point[0] - x0, intersection_point[1] - y0, intersection_point[2] - z0
-    if dot(nx, ny, nz, *cross(*subtract(x1, y1, z1, x0, y0, z0), *C0)) > 0.0:
+    if dot(nx, ny, nz, *cross(*subtract(x1, y1, z1, x0, y0, z0), *C0)) >= 0.0:
         C1 = intersection_point[0] - x1, intersection_point[1] - y1, intersection_point[2] - z1
-        if dot(nx, ny, nz, *cross(*subtract(x2, y2, z2, x1, y1, z1), *C1)) > 0.0:
+        if dot(nx, ny, nz, *cross(*subtract(x2, y2, z2, x1, y1, z1), *C1)) >= 0.0:
             C2 = intersection_point[0] - x2, intersection_point[1] - y2, intersection_point[2] - z2
-            if dot(nx, ny, nz, *cross(*subtract(x0, y0, z0, x2, y2, z2), *C2)) > 0.0:
+            if dot(nx, ny, nz, *cross(*subtract(x0, y0, z0, x2, y2, z2), *C2)) >= 0.0:
                 return d, *intersection_point
 
     return 0.0, 0.0, 0.0, 0.0

--- a/lib/vectors.py
+++ b/lib/vectors.py
@@ -159,11 +159,11 @@ class Line:
         intersection_point = self.origin + self.direction * d
 
         C0 = intersection_point - tri.origin
-        if normal.dot(tri.p1_to_p2.cross(C0)) > 0:
+        if normal.dot(tri.p1_to_p2.cross(C0)) >= 0:
             C1 = intersection_point - tri.p2
-            if normal.dot(tri.p2_to_p3.cross(C1)) > 0:
+            if normal.dot(tri.p2_to_p3.cross(C1)) >= 0:
                 C2 = intersection_point - tri.p3
-                if normal.dot(tri.p3_to_p1.cross(C2)) > 0:
+                if normal.dot(tri.p3_to_p1.cross(C2)) >= 0:
                     return intersection_point, d
 
         return False


### PR DESCRIPTION
When a ray was thrown from an edge of a triangle, the `Collision.collide_ray()` function would not hit said triangle, as edges were considered outside of the triangle.

This issue was surfaced while trying to ground objects that had been previously snapped to edges: the object would ignore the triangle that *almost* contained the object, and would be grounded to other triangles much further below.

`Line.collide()` has been updated with the fix, too, although the function is not currently used (superseded by the recent reimplementation with Numba).