### PR TITLE
Accept `0.0` as a valid triangle collision distance. 

### DIFF
--- a/lib/collision.py
+++ b/lib/collision.py
@@ -207,11 +207,11 @@ def _collide_ray_and_triangle(
 
     d = dot(nx, ny, nz, dx, dy, dz)
     if d == 0.0:
-        return 0.0, 0.0, 0.0, 0.0
+        return -1.0, 0.0, 0.0, 0.0
 
     d = dot(*subtract(x0, y0, z0, x, y, z), nx, ny, nz) / d
     if d < 0.0:
-        return 0.0, 0.0, 0.0, 0.0
+        return -1.0, 0.0, 0.0, 0.0
 
     intersection_point = x + dx * d, y + dy * d, z + dz * d
 
@@ -223,7 +223,7 @@ def _collide_ray_and_triangle(
             if dot(nx, ny, nz, *cross(*subtract(x0, y0, z0, x2, y2, z2), *C2)) > 0.0:
                 return d, *intersection_point
 
-    return 0.0, 0.0, 0.0, 0.0
+    return -1.0, 0.0, 0.0, 0.0
 
 
 @numba.jit(nopython=True, nogil=True, cache=True)
@@ -256,7 +256,7 @@ def _collide_ray_and_triangles(
             triangles[t * 9 + 8],
         )
 
-        if collision[0] > 0.0:
+        if collision[0] >= 0.0:
             collisions.append(collision)
 
     if collisions:

--- a/lib/collision.py
+++ b/lib/collision.py
@@ -179,7 +179,17 @@ def subtract(
 
 
 @numba.jit(nopython=True, nogil=True, cache=True)
-def _distance_between_line_and_point(x, y, z, dx, dy, dz, px, py, pz):
+def _distance_between_line_and_point(
+    x: float,
+    y: float,
+    z: float,
+    dx: float,
+    dy: float,
+    dz: float,
+    px: float,
+    py: float,
+    pz: float,
+) -> float:
     p1_to_p2 = subtract(dx + x, dy + y, dz + z, x, y, z)
     p3_to_p1 = subtract(x, y, z, px, py, pz)
     return length(*cross(*p1_to_p2, *p3_to_p1)) / length(*p1_to_p2)
@@ -202,7 +212,7 @@ def _collide_ray_and_triangle(
     x2: float,
     y2: float,
     z2: float,
-):
+) -> tuple[float, float, float, float]:
     nx, ny, nz = normal(x0, y0, z0, x1, y1, z1, x2, y2, z2)
 
     d = dot(nx, ny, nz, dx, dy, dz)


### PR DESCRIPTION
This was a regression with the new Numba-base triangle collision implementation, introduced in 0e7a34c37b1e.

`0.0` was inadvertently used to indicate "no collision", but that is a valid value when the ray origin is contained in the triangle. Grounding objects that were already grounded could result in objects being grounded to a much higher or lower triangle, as the closest triangle was wrongly disregarded.

`-1.0` is now used. (Note that Numba is strongly typed; returning `None` or other rich type is not possible.)