### PR TITLE
Drop usages of the deprecated `QMouseEvent.pos()` method.

### DIFF
--- a/editor_controls.py
+++ b/editor_controls.py
@@ -80,7 +80,7 @@ class ClickDragAction(MouseAction):
         self.first_click = None
 
     def just_clicked(self, editor, buttons, event):
-        self.first_click = event.pos()
+        self.first_click = event.position().toPoint()
 
     def move(self, editor, buttons, event):
 
@@ -105,7 +105,7 @@ class TopdownScroll(ClickDragAction):
         editor.offset_x += adjusted_dx
         editor.offset_z += adjusted_dz
         editor.do_redraw()
-        self.first_click = event.pos()
+        self.first_click = event.position().toPoint()
 
 
 class TopdownSelect(ClickDragAction):
@@ -160,7 +160,7 @@ class Gizmo2DMoveX(ClickDragAction):
         if editor.gizmo.was_hit["gizmo_x"]:
             editor.gizmo.set_render_axis(AXIS_X)
             delta_x = event.x() - self.first_click.x()
-            self.first_click = event.pos()
+            self.first_click = event.position().toPoint()
             editor.move_points.emit(delta_x*editor.zoom_factor, 0, 0)
 
     def just_released(self, editor, buttons, event):
@@ -181,7 +181,7 @@ class Gizmo2DMoveXZ(Gizmo2DMoveX):
             #editor.gizmo.set_render_axis(AXIS_X)
             delta_x = event.x() - self.first_click.x()
             delta_z = event.y() - self.first_click.y()
-            self.first_click = event.pos()
+            self.first_click = event.position().toPoint()
             editor.move_points.emit(delta_x*editor.zoom_factor, 0, delta_z*editor.zoom_factor)
 
 
@@ -190,7 +190,7 @@ class Gizmo2DMoveZ(Gizmo2DMoveX):
         if editor.gizmo.was_hit["gizmo_z"]:
             editor.gizmo.set_render_axis(AXIS_Z)
             delta_z = event.y() - self.first_click.y()
-            self.first_click = event.pos()
+            self.first_click = event.position().toPoint()
             editor.move_points.emit(0, 0, delta_z*editor.zoom_factor)
 
 
@@ -212,7 +212,7 @@ class Gizmo2DRotateY(Gizmo2DMoveX):
 
             editor.rotate_current.emit(Vector3(0, delta, 0))
 
-            self.first_click = event.pos()
+            self.first_click = event.position().toPoint()
 
     def just_released(self, editor, buttons, event):
         super().just_released(editor, buttons, event)
@@ -251,7 +251,7 @@ class View3DScroll(ClickDragAction):
         editor.offset_z += sideways_move.y * d_x
 
         editor.do_redraw()
-        self.first_click = event.pos()
+        self.first_click = event.position().toPoint()
 
 
 class RotateCamera3D(ClickDragAction):
@@ -388,7 +388,7 @@ class Gizmo3DMoveX(Gizmo2DMoveX):
                 0.0,
             ])
             delta[1] = -delta[1]
-            self.first_click = event.pos()
+            self.first_click = event.position().toPoint()
             delta_x = numpy.dot(delta, proj)
 
             if editor.shift_is_pressed:

--- a/mkdd_editor.py
+++ b/mkdd_editor.py
@@ -1105,7 +1105,7 @@ class GenEditor(QtWidgets.QMainWindow):
             def mousePressEvent(self, event):
                 super().mousePressEvent(event)
 
-                modelIndex = self.indexAt(event.pos())
+                modelIndex = self.indexAt(event.position().toPoint())
                 if not modelIndex.isValid():
                     self.clearSelection()
 

--- a/widgets/data_editor.py
+++ b/widgets/data_editor.py
@@ -180,7 +180,7 @@ class ClickableLabel(QtWidgets.QLabel):
 
     def mouseReleaseEvent(self, event):
 
-        if self.rect().contains(event.pos()):
+        if self.rect().contains(event.position().toPoint()):
             event.accept()
             self.clicked.emit()
 


### PR DESCRIPTION
The method has been deprecated since Qt 6.0. See https://doc.qt.io/qt-6/qmouseevent-obsolete.html#pos.

The following warning could be seen:
```
/w/mkdd-track-editor/mkdd_editor.py:1102: DeprecationWarning: Function: 'pos() const' is marked as deprecated, please check the documentation for more information.
  modelIndex = self.indexAt(event.pos())
```