### PR TITLE
Performance improvements in the tree view.

### DIFF
--- a/mkdd_editor.py
+++ b/mkdd_editor.py
@@ -2046,22 +2046,22 @@ class GenEditor(QtWidgets.QMainWindow):
         self.button_open_add_item_window()
 
     def select_tree_item_bound_to(self, objects):
-        new_item_selection = []
+        # Iteratively traverse all the tree widget items to retrieve all the bound objects.
+        bound_objects_and_items = []
+        pending_items = [self.leveldatatreeview.invisibleRootItem()]
+        while pending_items:
+            item = pending_items.pop(0)
+            for child_index in range(item.childCount()):
+                child_item = item.child(child_index)
+                if hasattr(child_item, 'bound_to') and child_item.bound_to is not None:
+                    bound_objects_and_items.append((child_item.bound_to, child_item))
+                pending_items.append(child_item)
 
+        new_item_selection = []
         for obj in objects:
-            # Iteratively traverse all the tree widget items.
-            pending_items = [self.leveldatatreeview.invisibleRootItem()]
-            while pending_items:
-                item = pending_items.pop(0)
-                for child_index in range(item.childCount()):
-                    child_item = item.child(child_index)
-                    # Check whether the item contains any item that happens to be bound to the
-                    # target object.
-                    bound_item = get_treeitem(child_item, obj)
-                    if bound_item is not None:
-                        new_item_selection.append(bound_item)
-                    else:
-                        pending_items.append(child_item)
+            for bound_object, item in bound_objects_and_items:
+                if obj is bound_object:
+                    new_item_selection.append(item)
 
         if new_item_selection:
             # If found, deselect current selection, and select the new item.

--- a/mkdd_editor.py
+++ b/mkdd_editor.py
@@ -548,7 +548,7 @@ class GenEditor(QtWidgets.QMainWindow):
         self.horizontalLayout = QtWidgets.QSplitter()
         self.centralwidget = self.horizontalLayout
         self.setCentralWidget(self.horizontalLayout)
-        self.leveldatatreeview = LevelDataTreeView(self.centralwidget)
+        self.leveldatatreeview = LevelDataTreeView(self, self.centralwidget)
         #self.leveldatatreeview.itemClicked.connect(self.tree_select_object)
         self.leveldatatreeview.itemDoubleClicked.connect(self.do_goto_action)
         self.leveldatatreeview.itemSelectionChanged.connect(self.tree_select_arrowkey)

--- a/widgets/tree_view.py
+++ b/widgets/tree_view.py
@@ -331,17 +331,18 @@ class LevelDataTreeView(QtWidgets.QTreeWidget):
         self.addTopLevelItem(group)
         return group
 
-    def reset(self):
-        self.enemyroutes.remove_children()
-        self.checkpointgroups.remove_children()
-        self.routes.remove_children()
-        self.objects.remove_children()
-        self.kartpoints.remove_children()
-        self.areas.remove_children()
-        self.cameras.remove_children()
-        self.respawnpoints.remove_children()
-        self.lightparams.remove_children()
-        self.mgentries.remove_children()
+    def _reset(self):
+        with QtCore.QSignalBlocker(self):  # Avoid triggering item selection changed events.
+            self.enemyroutes.remove_children()
+            self.checkpointgroups.remove_children()
+            self.routes.remove_children()
+            self.objects.remove_children()
+            self.kartpoints.remove_children()
+            self.areas.remove_children()
+            self.cameras.remove_children()
+            self.respawnpoints.remove_children()
+            self.lightparams.remove_children()
+            self.mgentries.remove_children()
 
     def set_objects(self, boldata: BOL):
         # Compute the location (based on indexes) of the currently selected items, if any.
@@ -366,7 +367,7 @@ class LevelDataTreeView(QtWidgets.QTreeWidget):
         checkpointgroups_expansion_states = self._get_expansion_states(self.checkpointgroups)
         routes_expansion_states = self._get_expansion_states(self.routes)
 
-        self.reset()
+        self._reset()
 
         for group in boldata.enemypointgroups.groups:
             group_item = EnemyPointGroup(self.enemyroutes, group)


### PR DESCRIPTION
These changes aim to improve the UI responsiveness when undo/redo actions are triggered while many tree items are selected.

Generally, redundant item selection changed events are now avoided in `LevelDataTreeView.set_objects()`, as well as other improvements in the algorithm that finds the tree items associated with a given list of bound objects (the objects in the BOL).

**Test plan:**

- Load Rainbow Road.
- Select all objects with a marquee selection.
- Move all objects a few hundreds units downwards.
- Press `Ctrl+Z` to undo the operation.

Without these fixes, the UI gets frozen for `~22 seconds`. In the output from cProfile:
```
1    0.000    0.000   22.165   22.165 /w/mkdd-track-editor/mkdd_editor.py:272(load_top_undo_entry)
```

With these fixes, the operation takes `0.046 seconds`:
```
1    0.000    0.000    0.046    0.046 /w/mkdd-track-editor/mkdd_editor.py:272(load_top_undo_entry)
```