### PR TITLE
Spinboxes for numerical fields in data editor.

### DIFF
--- a/lib/libbol.py
+++ b/lib/libbol.py
@@ -677,7 +677,9 @@ class Route(object):
         #pad = f.read(4)
         #assert pad == b"\x00\x00\x00\x00"
         route.unk1 = read_uint32(f)
+        assert route.unk1 in (0, 1)
         route.unk2 = read_uint8(f)
+        assert route.unk2 == 0
         pad = f.read(7)
         assert pad == b"\x00"*7
 

--- a/mkdd_editor.py
+++ b/mkdd_editor.py
@@ -2919,12 +2919,29 @@ class Application(QtWidgets.QApplication):
 
     document_potentially_changed = QtCore.Signal()
 
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        self._pending_focus_change = False
+
+        self.focusChanged.connect(self._on_focus_changed)
+
     def notify(self, receiver: QtCore.QObject, event: QtCore.QEvent) -> bool:
         if event.type() in POTENTIALLY_EDITING_EVENTS:
             if isinstance(receiver, QtGui.QWindow):
-                QtCore.QTimer.singleShot(0, self.document_potentially_changed)
+                # Certain widget types are known to submit many value changes while they have focus.
+                # Potentially-editing events will be disregarded until focus is out (unless there
+                # have been a recent focus change)
+                disregardable = isinstance(self.focusWidget(), QtWidgets.QAbstractSpinBox)
+                if not disregardable or self._pending_focus_change:
+                    self._pending_focus_change = False
+                    QtCore.QTimer.singleShot(0, self.document_potentially_changed)
 
         return super().notify(receiver, event)
+
+    def _on_focus_changed(self, old: QtWidgets.QWidget, now: QtWidgets.QWidget):
+        _ = old, now
+        self._pending_focus_change = True
 
 
 if __name__ == "__main__":

--- a/widgets/data_editor.py
+++ b/widgets/data_editor.py
@@ -872,15 +872,11 @@ class CheckpointEdit(DataEditor):
 
 class ObjectRouteEdit(DataEditor):
     def setup_widgets(self):
-        self.unk1 = self.add_integer_input("Unknown 1", "unk1",
-                                           MIN_UNSIGNED_INT, MAX_UNSIGNED_INT)
-        self.unk2 = self.add_integer_input("Unknown 2", "unk2",
-                                           MIN_UNSIGNED_BYTE, MAX_UNSIGNED_BYTE)
+        self.unk1 = self.add_checkbox("Unknown 1", "unk1", 0, 1)
 
     def update_data(self):
         obj: Route = self.bound_to
-        self.unk1.setText(str(obj.unk1))
-        self.unk2.setText(str(obj.unk2))
+        self.unk1.setChecked(bool(obj.unk1))
 
 
 class ObjectRoutePointEdit(DataEditor):


### PR DESCRIPTION
`QtWidgtes.QSpinBox` and `QtWidgets.QDoubleSpinBox` are now use for numerical values in the data editor. Previously, a combination of text edits and integer validators were used, with suffered from considerable rounding errors during the `str` to `int`/`float` conversion.

Spinboxes allow users to incrementally change values by clicking the increment or decrement buttons. In addition, mouse wheel, keyboard arrows, or page up/down keys now be used too. The `Ctrl` keyboard modifier can be used to apply a applier a modifier to the step.

Spin buttons are intentionally hidden for floating-point types; the gained extra space is used for displaying decimals.