### PR TITLE
Update data editor when checkpoint end is selected.

### DIFF
--- a/mkdd_editor.py
+++ b/mkdd_editor.py
@@ -2780,9 +2780,9 @@ class GenEditor(QtWidgets.QMainWindow):
                 if suppress_signal:
                     self.leveldatatreeview.blockSignals(False)
 
-            if item is None:
-                # If no item was selected, no tree item will be selected, and the data editor needs
-                # to be updated manually.
+            if item is None or suppress_signal:
+                # If no item was selected, or the signal was suppressed, no tree item will be
+                # selected, and the data editor needs to be updated manually.
                 self.action_update_info()
 
             #if nothing is selected and the currentitem is something that can be selected


### PR DESCRIPTION
This was a regression introduced in f095e3145b33.

When one of the two checkpoint ends are selected in the viewport, the checkpoint was highlighted in the tree view, but the data was not shown in the data editor due to signal having been temporarily suppressed.