### PR TITLE
Drop deprecated `QApplication.fontMetrics()`.

### DIFF
--- a/mkdd_editor.py
+++ b/mkdd_editor.py
@@ -3101,7 +3101,7 @@ if __name__ == "__main__":
     app.setPalette(palette)
 
     QtWidgets.QToolTip.setPalette(palette)
-    padding = app.fontMetrics().height() // 2
+    padding = QtGui.QFontMetrics(QtGui.QFont()).height() // 2
     app.setStyleSheet(f'QToolTip {{ padding: {padding}px; }}')
 
     if platform.system() == "Windows":


### PR DESCRIPTION
The following warning could be seen on startup:
```
C:\trash\mkdd-track-editor\mkdd_editor.py:3104: DeprecationWarning: Function: 'QApplication.fontMetrics()' is marked as deprecated, please check the documentation for more information.
  padding = app.fontMetrics().height() // 2
```

The function was deprecated in Qt 6.0, although warnings are only produced more modern versions (Qt 6.5).