### PR TITLE
Verify document state after selection in viewport.

### DIFF
--- a/mkdd_widgets.py
+++ b/mkdd_widgets.py
@@ -950,6 +950,11 @@ class BolMapViewer(QtOpenGLWidgets.QOpenGLWidget):
 
             self.editor.select_from_3d_to_treeview()
 
+            # The selection action, that depends on the viewport draw call, may have occurred later
+            # than the actual click event (i.e. after the document state has been checked). The
+            # document needs to be checked again to determine whether the selection has changed.
+            self.editor.on_document_potentially_changed(update_unsaved_changes=False)
+
             self.gizmo.move_to_average(self.selected_positions, self.selected_rotations)
             if len(selected) == 0:
                 self.gizmo.hidden = True


### PR DESCRIPTION
Follow-up to e5c13a4fef0e832648d, where the Undo system now monitors changes in the selection set.

In order to accurately detect changes in selection, the document state needs to be re-verified after a selection occurs in the viewport. The viewport selection is not fully synced with the mouse press event: it can happen instants later, after the document state has been changed as a result of the potentially-editing event (i.e. the mouse click event).

The issue was easily reproducible on Windows.