### PR TITLE
Reimplement infinite grid with more primitive GL operations.

### DIFF
--- a/configuration.py
+++ b/configuration.py
@@ -24,7 +24,7 @@ def make_default_config():
         "wasdscrolling_speed": "1250",
         "wasdscrolling_speedupfactor": "5",
         "multisampling": "8",
-        "3d_background": "100 100 100",
+        "3d_background": "90 90 90",
         "hidden_collision_types": "",
         "hidden_collision_type_groups": "",
         "filter_view": "",

--- a/lib/model_rendering.py
+++ b/lib/model_rendering.py
@@ -786,11 +786,12 @@ class Minimap(object):
 
 
 class Grid(Mesh):
-    def __init__(self, width, length, step):
+    def __init__(self, width, length, step, color):
         super().__init__("Grid")
         self.width = width
         self.length = length
         self.step = step
+        self.color = color
 
     def generate_displist(self):
         if self._displist is not None:
@@ -802,7 +803,7 @@ class Grid(Mesh):
 
         self._displist = glGenLists(1)
         glNewList(self._displist, GL_COMPILE)
-        glColor3f(0.2, 0.2, 0.2)
+        glColor4f(*self.color)
         glLineWidth(4.0)
         glBegin(GL_LINES)
         glVertex3f(-width, 0, offset)


### PR DESCRIPTION
The previous implementation, based on `GL_FOG`, could show different results depending on the implementation of the `GL_NICEST` *hint*. In some Linux systems, the hint triggers a per-fragment shading (as desired for our use case) but, on Windows systems, the shading is generally done per-vertex, which was not ideal.

In the new reimplementation, the infinite grid is achieved by painting the grid with the same sky color; lines accumulating in the horizon give the *false* impression of a fog. Similarly, the ground is painted with a gradient that converges into the sky color.

<img src="https://github.com/RenolY2/mkdd-track-editor/assets/1853278/ec2b15b6-9368-43a8-96b4-56f569045610" alt="MKDD Track Editor - Infinite Grid Reimplementation" title="MKDD Track Editor - Infinite Grid Reimplementation" width="540"/>