### PR TITLE
Preserve window state when toggling fullscreen mode.

### DIFF
--- a/mkdd_editor.py
+++ b/mkdd_editor.py
@@ -881,8 +881,9 @@ class GenEditor(QtWidgets.QMainWindow):
         self.fullscreen = self.view_menu.addAction('Fullscreen')
         self.fullscreen.setShortcut(QtGui.QKeySequence(QtCore.Qt.Key_F11))
         self.fullscreen.setCheckable(True)
-        self.fullscreen.triggered[bool].connect(lambda checked: self.showFullScreen()
-                                                if checked else self.showNormal())
+        self.fullscreen.triggered[bool].connect(lambda checked: self.setWindowState(
+            (self.windowState() | QtCore.Qt.WindowFullScreen)
+            if checked else (self.windowState() & ~QtCore.Qt.WindowFullScreen)))
 
         # Misc
         self.misc_menu = QtWidgets.QMenu(self.menubar)


### PR DESCRIPTION
The use of `showNormal()` when toggling off fullscreen mode would prevent the window from coming back to its potential maximized state (provided it was already maximized upon entering fullscreen mode).

**Test plan:**
- Resize the main window to a small portion of the display.
- Maximize the window.
- Press `F11` to enter fullscreen mode.
- Press `F11` to abandon fullscreen mode.

Without this fix, the window does not come back to the maximized state; instead, the very initial small window is shown.

With the fix, the window comes back to the maximized state.