### PR TITLE
Revise behavior of the camera actions in the 3D view.

### DIFF
--- a/editor_controls.py
+++ b/editor_controls.py
@@ -242,13 +242,13 @@ class View3DScroll(ClickDragAction):
 
         forward_vec = Vector3(cos(editor.camera_horiz), sin(editor.camera_horiz), 0)
         forward_move = forward_vec * speed * speedup
-        editor.offset_x += forward_move.x * d_y
-        editor.offset_z += forward_move.y * d_y
+        editor.camera_x += forward_move.x * d_y
+        editor.camera_z += forward_move.y * d_y
 
         sideways_vec = Vector3(-sin(editor.camera_horiz), cos(editor.camera_horiz), 0)
         sideways_move = sideways_vec * speed * speedup
-        editor.offset_x += sideways_move.x * d_x
-        editor.offset_z += sideways_move.y * d_x
+        editor.camera_x += sideways_move.x * d_x
+        editor.camera_z += sideways_move.y * d_x
 
         editor.do_redraw()
         self.first_click = event.position().toPoint()

--- a/editor_controls.py
+++ b/editor_controls.py
@@ -238,7 +238,7 @@ class View3DScroll(ClickDragAction):
         if editor.shift_is_pressed:
             speedup = editor._wasdscrolling_speedupfactor
 
-        speed = editor._wasdscrolling_speed / 25
+        speed = editor._wasdscrolling_speed * (min(100000.0, editor.camera_height) / 1000000.0)
 
         forward_vec = Vector3(cos(editor.camera_horiz), sin(editor.camera_horiz), 0)
         forward_move = forward_vec * speed * speedup

--- a/editor_controls.py
+++ b/editor_controls.py
@@ -293,8 +293,6 @@ class Select3D(ClickDragAction):
     def just_clicked(self, editor, buttons, event):
         super().just_clicked(editor, buttons, event)
 
-        editor.camera_direction.normalize()
-
         ray = editor.create_ray_from_mouseclick(event.x(), event.y())
         editor.selectionbox_projected_origin = ray.origin + ray.direction*ufac# * 0.1
         editor.selectionbox_projected_coords = None

--- a/lib/game_visualizer.py
+++ b/lib/game_visualizer.py
@@ -236,14 +236,13 @@ class Game(object):
                     newx = sin(angle + pi/2.0)
                     newz = cos(angle + pi/2.0)
 
-                    #renderer.offset_x = (self.karts[self.stay_focused_on_player][1].x
+                    #renderer.camera_x = (self.karts[self.stay_focused_on_player][1].x
                     #                     - self.kart_headings[self.stay_focused_on_player].x*1000)
-                    #renderer.offset_z = -(self.karts[self.stay_focused_on_player][1].z
+                    #renderer.camera_z = -(self.karts[self.stay_focused_on_player][1].z
                     #                      - self.kart_headings[self.stay_focused_on_player].z*1000)
-                    renderer.offset_x = (self.karts[self.stay_focused_on_player][1].x
-                                         - newx * 1000)
-                    renderer.offset_z = -(self.karts[self.stay_focused_on_player][1].z
-                                          - newz * 1000)
+                    renderer.camera_x = (self.karts[self.stay_focused_on_player][1].x - newx * 1000)
+                    renderer.camera_z = -(self.karts[self.stay_focused_on_player][1].z -
+                                          newz * 1000)
                     height = self.karts[self.stay_focused_on_player][1].y
                     #if height < renderer.camera_height:
                     renderer.camera_height = height+500

--- a/mkdd_editor.py
+++ b/mkdd_editor.py
@@ -174,8 +174,6 @@ class GenEditor(QtWidgets.QMainWindow):
         self.dolphin = Game()
         self.level_view.dolphin = self.dolphin
 
-        self.first_time_3dview = True
-
         self.restore_geometry()
 
         self.fullscreen.setChecked(
@@ -1499,12 +1497,6 @@ class GenEditor(QtWidgets.QMainWindow):
         if checked:
             self.level_view.change_from_topdown_to_3d()
             self.statusbar.clearMessage()
-
-            # After switching to the 3D view for the first time, the view will be framed to help
-            # users find the objects in the world.
-            if self.first_time_3dview:
-                self.first_time_3dview = False
-                self.frame_selection(adjust_zoom=True)
 
     def setup_ui_toolbar(self):
         # self.toolbar = QtWidgets.QToolBar("Test", self)

--- a/mkdd_editor.py
+++ b/mkdd_editor.py
@@ -486,7 +486,7 @@ class GenEditor(QtWidgets.QMainWindow):
                     DEFAULT_ZOOM = 80
                     self.level_view._zoom_factor = max(hzoom, vzoom, DEFAULT_ZOOM)
         else:
-            look = self.level_view.camera_direction.copy()
+            look = self.level_view.camera_direction
 
             if adjust_zoom:
                 MARGIN = 3000

--- a/mkdd_editor.py
+++ b/mkdd_editor.py
@@ -245,7 +245,7 @@ class GenEditor(QtWidgets.QMainWindow):
         self.loaded_archive = None
         self.loaded_archive_file = None
         self.object_to_be_added = None
-        self.level_view.reset(keep_collision=True)
+        self.level_view.reset()
 
         self.current_coordinates = None
         for key, val in self.editing_windows.items():
@@ -2694,10 +2694,6 @@ class GenEditor(QtWidgets.QMainWindow):
 
         if event.key() == QtCore.Qt.Key_Shift:
             self.level_view.shift_is_pressed = True
-        elif event.key() == QtCore.Qt.Key_R:
-            self.level_view.rotation_is_pressed = True
-        elif event.key() == QtCore.Qt.Key_H:
-            self.level_view.change_height_is_pressed = True
 
         if event.key() == QtCore.Qt.Key_W:
             self.level_view.MOVE_FORWARD = 1
@@ -2720,10 +2716,6 @@ class GenEditor(QtWidgets.QMainWindow):
     def keyReleaseEvent(self, event: QtGui.QKeyEvent):
         if event.key() == QtCore.Qt.Key_Shift:
             self.level_view.shift_is_pressed = False
-        elif event.key() == QtCore.Qt.Key_R:
-            self.level_view.rotation_is_pressed = False
-        elif event.key() == QtCore.Qt.Key_H:
-            self.level_view.change_height_is_pressed = False
 
         if event.key() == QtCore.Qt.Key_W:
             self.level_view.MOVE_FORWARD = 0

--- a/mkdd_editor.py
+++ b/mkdd_editor.py
@@ -495,8 +495,8 @@ class GenEditor(QtWidgets.QMainWindow):
             else:
                 fac = 5000
 
-            self.level_view.offset_z = -(z + look.y * fac)
-            self.level_view.offset_x = x - look.x * fac
+            self.level_view.camera_z = -(z + look.y * fac)
+            self.level_view.camera_x = x - look.x * fac
             self.level_view.camera_height = y - look.z * fac
 
         self.level_view.do_redraw()

--- a/mkdd_widgets.py
+++ b/mkdd_widgets.py
@@ -154,7 +154,7 @@ class BolMapViewer(QtOpenGLWidgets.QOpenGLWidget):
                                  sin(self.camera_vertical))
         fac = 1.01 - abs(look_direction.z)
         self.camera_direction = Vector3(look_direction.x * fac, look_direction.y * fac,
-                                        look_direction.z)
+                                        look_direction.z).normalized()
 
         self.selectionqueue = SelectionQueue()
 
@@ -571,7 +571,8 @@ class BolMapViewer(QtOpenGLWidgets.QOpenGLWidget):
                       self.camera_height + look_direction.z,
                       0, 0, 1)
 
-            self.camera_direction = Vector3(look_direction.x * fac, look_direction.y * fac, look_direction.z)
+            self.camera_direction = Vector3(look_direction.x * fac, look_direction.y * fac,
+                                            look_direction.z).normalized()
 
         self.modelviewmatrix = numpy.transpose(numpy.reshape(glGetFloatv(GL_MODELVIEW_MATRIX), (4,4)))
         self.projectionmatrix = numpy.transpose(numpy.reshape(glGetFloatv(GL_PROJECTION_MATRIX), (4,4)))
@@ -1445,9 +1446,7 @@ class BolMapViewer(QtOpenGLWidgets.QOpenGLWidget):
             speedup *= self._wasdscrolling_speedupfactor
         speed = self._wasdscrolling_speed / 2
 
-        self.camera_direction.normalize()
-        view = self.camera_direction.copy()
-        view = view * speed * speedup
+        view = self.camera_direction * speed * speedup
 
         self.offset_x += view.x
         self.camera_height += view.z
@@ -1456,11 +1455,10 @@ class BolMapViewer(QtOpenGLWidgets.QOpenGLWidget):
         self.do_redraw()
 
     def create_ray_from_mouseclick(self, mousex, mousey, yisup=False):
-        self.camera_direction.normalize()
         height = self.canvas_height
         width = self.canvas_width
 
-        view = self.camera_direction.copy()
+        view = self.camera_direction
 
         h = view.cross(Vector3(0, 0, 1))
         v = h.cross(view)

--- a/mkdd_widgets.py
+++ b/mkdd_widgets.py
@@ -585,9 +585,21 @@ class BolMapViewer(QtOpenGLWidgets.QOpenGLWidget):
             glMatrixMode(GL_MODELVIEW)
             glLoadIdentity()
         else:
+            campos = Vector3(offset_x, self.camera_height, -offset_z)
+
             glMatrixMode(GL_PROJECTION)
             glLoadIdentity()
-            gluPerspective(75, width / height, 256.0, 160000.0)
+
+            far_plane = 160000.0
+            if self.collision is not None and self.collision.extent is not None:
+                collision_center = Vector3(
+                    self.collision.extent[3] + self.collision.extent[0],
+                    self.collision.extent[5] + self.collision.extent[2],
+                    -(self.collision.extent[4] + self.collision.extent[1])) / 2.0
+                camera_distance = (campos - collision_center).length()
+                far_plane = max(far_plane, camera_distance * 2.0)
+
+            gluPerspective(75, width / height, 256.0, far_plane)
 
             glMatrixMode(GL_MODELVIEW)
             glLoadIdentity()
@@ -607,8 +619,6 @@ class BolMapViewer(QtOpenGLWidgets.QOpenGLWidget):
         self.modelviewmatrix = numpy.transpose(numpy.reshape(glGetFloatv(GL_MODELVIEW_MATRIX), (4,4)))
         self.projectionmatrix = numpy.transpose(numpy.reshape(glGetFloatv(GL_PROJECTION_MATRIX), (4,4)))
         self.mvp_mat = numpy.dot(self.projectionmatrix, self.modelviewmatrix)
-
-        campos = Vector3(offset_x, self.camera_height, -offset_z)
 
         vismenu: FilterViewMenu = self.visibility_menu
 


### PR DESCRIPTION
- Keep camera position for each view mode stored in their own members.
- Adjust camera positions when toggling between each view mode based on the current target point, so that the switch goes seamlessly.
- Dollying/trucking in 3D view based on camera height, instead of hardcoded value.
- Implemented forward and backwards action in 3D view based on camera direction, making it effectively a "free view" camera.
- Far plane in 3D view is dynamically adjusted to attempt to keep the model visible even when the user moves the camera far away.