### PR TITLE
Avoid skipping enumeration index in camera selection.

### DIFF
--- a/mkdd_widgets.py
+++ b/mkdd_widgets.py
@@ -779,9 +779,8 @@ class BolMapViewer(QtOpenGLWidgets.QOpenGLWidget):
                     offset = len(objlist)
 
                 if vismenu.cameras.is_selectable():
-                    for i, obj in enumerate(obj for obj in self.level_file.cameras if obj not in selected):
-                        if obj.name == "para":
-                            continue
+                    for i, obj in enumerate(obj for obj in self.level_file.cameras
+                                            if obj not in selected and obj.name != "para"):
                         if obj.camtype in (5, 6):
                             objlist.append(
                                 ObjectSelectionEntry(obj=obj,


### PR DESCRIPTION
Regression in ad7e69babe41daed.

An early-out check was introduced to skip cameras with the `para` name, altering the enumeration index that is used to access selected objects later on.

Reproduction steps:

- Add a camera.
- Set its **name** parameter to `para`.
- Add another camera.
- In the viewport, attempt to select the second camera.
- The following exception is produced:

```
Traceback (most recent call last):
  File "/w/mkdd-track-editor/mkdd_widgets.py", line 852, in paintGL
    entry: ObjectSelectionEntry = objlist[index // 4]
IndexError: list index out of range
```