### PR TITLE
Prevent exception when undoing selection after having selected the BOL header tree item.

### DIFF
--- a/mkdd_editor.py
+++ b/mkdd_editor.py
@@ -402,7 +402,7 @@ class GenEditor(QtWidgets.QMainWindow):
                 for row in reversed(selected_item_data):
                     item = item.child(row)
                 item.setSelected(True)
-                if isinstance(item.bound_to, libbol.Checkpoint):
+                if hasattr(item, 'bound_to') and isinstance(item.bound_to, libbol.Checkpoint):
                     # Handled as a special case.
                     continue
                 items_to_select.append(item)


### PR DESCRIPTION
Reproduction steps:

- Launch the Editor.
- Select the **Track Settings** top-level tree item.
- Select a different tree item.
- Press `Ctrl+Z` to undo the selection.
- The following exception is raised:
```
Traceback (most recent call last):
  File "/w/mkdd-track-editor/mkdd_editor.py", line 422, in on_undo_action_triggered
    self.load_top_undo_entry()
  File "/w/mkdd-track-editor/mkdd_editor.py", line 405, in load_top_undo_entry
    if isinstance(item.bound_to, libbol.Checkpoint):
AttributeError: 'BolHeader' object has no attribute 'bound_to'
```