### PR TITLE
Always restore selected state of the top-level tree items when a BOL document is set.

### DIFF
--- a/widgets/tree_view.py
+++ b/widgets/tree_view.py
@@ -386,6 +386,18 @@ class LevelDataTreeView(QtWidgets.QTreeWidget):
 
     def _reset(self):
         with QtCore.QSignalBlocker(self):  # Avoid triggering item selection changed events.
+            self.bolheader.setSelected(False)
+            self.enemyroutes.setSelected(False)
+            self.checkpointgroups.setSelected(False)
+            self.routes.setSelected(False)
+            self.objects.setSelected(False)
+            self.kartpoints.setSelected(False)
+            self.areas.setSelected(False)
+            self.cameras.setSelected(False)
+            self.respawnpoints.setSelected(False)
+            self.lightparams.setSelected(False)
+            self.mgentries.setSelected(False)
+
             self.enemyroutes.remove_children()
             self.checkpointgroups.remove_children()
             self.routes.remove_children()

--- a/widgets/tree_view.py
+++ b/widgets/tree_view.py
@@ -480,11 +480,17 @@ class LevelDataTreeView(QtWidgets.QTreeWidget):
         self._set_expansion_states(self.checkpointgroups, checkpointgroups_expansion_states)
         self._set_expansion_states(self.routes, routes_expansion_states)
 
-        # And restore previous selection (but only if item counts match, or else indexes could be
-        # unreliable).
+        # And restore previous selection, but only if item counts match, or else indexes could be
+        # unreliable. Top-level items always exist, so they can be restored even when the count has
+        # changed.
         items_to_select = []
-        if selected_item_indexes_list and initial_item_count == self.count_items():
+        if selected_item_indexes_list:
+            only_top_level_items = initial_item_count != self.count_items()
+
             for selected_item_indexes in selected_item_indexes_list:
+                if only_top_level_items and len(selected_item_indexes) != 1:
+                    continue
+
                 item = self.topLevelItem(selected_item_indexes.pop(0))
                 while selected_item_indexes:
                     index = selected_item_indexes.pop(0)


### PR DESCRIPTION
Previously, selected state was only restored if the tree item count had not changed; now top-level tree items always get their selected state back. This is specially important for the BOL header tree item.

Reproduction steps:

- Load a course (e.g. Yoshi Circuit).
- Select the first top-level tree item (i.e. the **Track Settings** item, that shows the settings of the BOL header).
- Load a different course (e.g. Rainbow Road).
- Verify that the tree item remains selected, and that the data editor remains visible and showing the correct values of the second course.