### PR TITLE
Replace emoji used for Robbery mode in **Game Mode Presense** field.

### DIFF
--- a/widgets/data_editor.py
+++ b/widgets/data_editor.py
@@ -998,7 +998,7 @@ class ObjectEdit(DataEditor):
         self.presence_filter = self.add_maskbox(
             "Game Mode Presence", "presence_filter", {
                 0b00000001: ('🎈', 'Balloon Battle'),
-                0b00000010: ('🥷', 'Robbery (Yanked)'),
+                0b00000010: ('💰', 'Robbery (Yanked)'),
                 0b00000100: ('💣', 'Bob-omb Blast'),
                 0b00001000: ('🌟', 'Shine Thief'),
                 0b10000000: ('⏱️', 'Time Trials'),


### PR DESCRIPTION
The previous emoji (ninja / 🥷) was not fully supported on Windows systems at this time; the new emoji (money bag / 💰) appears to be supported in all tested systems.

Before and after:

![MKDD Track Editor - Robbery Icon (before)](https://github.com/RenolY2/mkdd-track-editor/assets/1853278/b234cb22-6430-41ce-bcdf-106cc4c0f3ed)
![MKDD Track Editor - Robbery Icon (after)](https://github.com/RenolY2/mkdd-track-editor/assets/1853278/33dbe1b3-723d-4608-9fb0-b5a0a3db3c2a)