### PR TITLE
Reset move flags on focus out events.

### DIFF
--- a/mkdd_editor.py
+++ b/mkdd_editor.py
@@ -2724,6 +2724,13 @@ class GenEditor(QtWidgets.QMainWindow):
         self.set_has_unsaved_changes(True)
 
     def keyPressEvent(self, event: QtGui.QKeyEvent):
+        if event.key() == QtCore.Qt.Key_Plus:
+            self.level_view.zoom_in()
+        elif event.key() == QtCore.Qt.Key_Minus:
+            self.level_view.zoom_out()
+
+        if event.isAutoRepeat():
+            return
 
         if event.key() == QtCore.Qt.Key_Escape:
             self.level_view.set_mouse_mode(mkdd_widgets.MOUSE_MODE_NONE)
@@ -2748,12 +2755,10 @@ class GenEditor(QtWidgets.QMainWindow):
         elif event.key() == QtCore.Qt.Key_E:
             self.level_view.MOVE_DOWN = 1
 
-        if event.key() == QtCore.Qt.Key_Plus:
-            self.level_view.zoom_in()
-        elif event.key() == QtCore.Qt.Key_Minus:
-            self.level_view.zoom_out()
-
     def keyReleaseEvent(self, event: QtGui.QKeyEvent):
+        if event.isAutoRepeat():
+            return
+
         if event.key() == QtCore.Qt.Key_Shift:
             self.level_view.shift_is_pressed = False
 

--- a/mkdd_editor.py
+++ b/mkdd_editor.py
@@ -2783,8 +2783,6 @@ class GenEditor(QtWidgets.QMainWindow):
         self.level_view.MOVE_UP = 0
         self.level_view.MOVE_DOWN = 0
         self.level_view.shift_is_pressed = False
-        self.level_view.rotation_is_pressed = False
-        self.level_view.change_height_is_pressed = False
 
     def action_rotate_object(self, deltarotation):
         #obj.set_rotation((None, round(angle, 6), None))

--- a/mkdd_widgets.py
+++ b/mkdd_widgets.py
@@ -247,6 +247,10 @@ class BolMapViewer(QtOpenGLWidgets.QOpenGLWidget):
                          GL_FLOAT, None)
             glBindTexture(GL_TEXTURE_2D, 0)
 
+    def focusOutEvent(self, event: QtGui.QFocusEvent):
+        super().focusOutEvent(event)
+        self.editor.reset_move_flags()
+
     @catch_exception
     def set_editorconfig(self, config):
         self.editorconfig = config


### PR DESCRIPTION
This stops the viewer from applying continual move actions to the viewport camera after the viewport loses focus while a move key is down.

Reproduction steps:
- While focusing the viewer, press `A` to move the viewport camera to the left.
- Without releasing the key, click on any top-bar menu (e.g. the **File** menu), or in any other widget outside of the viewport area that is capable of acquiring focus.
- Release the `A` key.

The viewer will not detect that the key was released, and it would continue to move the viewport camera to the left indefinitely (until the `A` key was toggled again).