### PR TITLE
Remove trailing spaces.

### DIFF
--- a/lib/collision.py
+++ b/lib/collision.py
@@ -109,7 +109,7 @@ class Collision:
         for i, point in enumerate(points):
             if clip_y is not None and point.z > clip_y:
                 continue
-                
+
             try:
                 distance = _distance_between_line_and_point(
                     ray.origin.x,

--- a/lib/model_rendering.py
+++ b/lib/model_rendering.py
@@ -947,16 +947,14 @@ class CollisionModel(object):
         out vec3 vecColor;
         vec3 selectedcol = vec3(1.0, 0.0, 0.0);
         vec3 lightvec = normalize(vec3(0.3, 0.0, -1.0));
-        
+
         void main(void)
         {
             vecNormal = normal;
             vec3 col = (1-interpolate) * color + interpolate*selectedcol;
             vecColor = col*clamp(1.0-dot(lightvec, normal), 0.3, 1.0);
             gl_Position = gl_ModelViewProjectionMatrix * vert;
-            
         }
-        
         """
 
         fragshader = """
@@ -964,9 +962,9 @@ class CollisionModel(object):
         in vec3 vecNormal;
         in vec3 vecColor;
         out vec4 finalColor;
-        
+
         void main (void)
-        {   
+        {
             finalColor = vec4(vecColor, 1.0);
         }"""
 

--- a/lib/superbmd/README.md
+++ b/lib/superbmd/README.md
@@ -1,14 +1,14 @@
 Get the newest version of SuperBMD at https://github.com/RenolY2/SuperBMD/releases
-This copy of SuperBMD is only meant for use with the MKDD Bol Editor's BMD rendering feature which works by converting 
+This copy of SuperBMD is only meant for use with the MKDD Bol Editor's BMD rendering feature which works by converting
 the bmd into a wavefront obj file and then rendering the obj file.
 
 
 ## Attribution
-Special thanks to Gamma (Sage-of-Mirrors) for creating SuperBMD, to LagoLunatic for the work on their fork that 
+Special thanks to Gamma (Sage-of-Mirrors) for creating SuperBMD, to LagoLunatic for the work on their fork that
 this fork is now based on (based on LagoLunatic's fork from December 2018), and to Hackio for their contributions to this fork.
 And special thanks goes out to everybody who uses this fork, reports issues and helps makes it a better tool.
 
-This project uses a number of external libraries or parts of them in the code which will be listed here 
+This project uses a number of external libraries or parts of them in the code which will be listed here
 together with their license if necessary:
 
 * BrawlLib: Tristripping algorithm by ernie, blackjax & tfautre:  https://github.com/libertyernie/brawltools

--- a/mkdd_editor.py
+++ b/mkdd_editor.py
@@ -739,7 +739,7 @@ class GenEditor(QtWidgets.QMainWindow):
         self.paste_action.setShortcut(QtGui.QKeySequence('Ctrl+V'))
         self.paste_action.triggered.connect(self.on_paste_action_triggered)
 
-        # ---- Visibility 
+        # ---- Visibility
         self.visibility_menu = mkdd_widgets.FilterViewMenu(self)
         self.visibility_menu.filter_update.connect(self.on_filter_update)
         filters = self.editorconfig["filter_view"].split(",")

--- a/widgets/tree_view.py
+++ b/widgets/tree_view.py
@@ -358,7 +358,7 @@ class LevelDataTreeView(QtWidgets.QTreeWidget):
             select_all_group.triggered.connect(emit_select_route)
 
             context_menu.addAction(select_all_group)
-        
+
         if isinstance(item, (ObjectEntry, CameraEntry)):
             if item.bound_to.route is not None:
                 select_assoc_action = QtGui.QAction("Select Associated Route", self)


### PR DESCRIPTION
There are still files with trailing spaces (e.g. `bti.py`, `rarc.py`, or `dolreader.py`), but they will be tackled at another time, as they are files imported from other projects which also don't change often.