### PR TITLE
Add support for Python 3.11.

### DIFF
--- a/mkdd_editor.py
+++ b/mkdd_editor.py
@@ -669,7 +669,6 @@ class GenEditor(QtWidgets.QMainWindow):
         self.snapping_cycle_shortcut.activated.connect(self.level_view.cycle_snapping_mode)
 
         QtGui.QShortcut(QtGui.QKeySequence(QtCore.Qt.Key_G), self).activated.connect(self.action_ground_objects)
-        #QtGui.QShortcut(QtCore.Qt.CTRL + QtCore.Qt.Key_A, self).activated.connect(self.shortcut_open_add_item_window)
         self.statusbar = QtWidgets.QStatusBar(self)
         self.statusbar.setObjectName("statusbar")
         self.setStatusBar(self.statusbar)
@@ -690,8 +689,6 @@ class GenEditor(QtWidgets.QMainWindow):
             QtGui.QKeySequence(QtCore.QKeyCombination(QtCore.Qt.ControlModifier, QtCore.Qt.Key_V)),
             self.file_menu)
         save_file_shortcut.activated.connect(self.button_save_level)
-        #QtGui.QShortcut(QtCore.Qt.CTRL + QtCore.Qt.Key_O, self.file_menu).activated.connect(self.button_load_level)
-        #QtGui.QShortcut(QtCore.Qt.CTRL + QtCore.Qt.Key_Alt + QtCore.Qt.Key_S, self.file_menu).activated.connect(self.button_save_level_as)
 
         self.file_load_action = QtGui.QAction("Load", self)
         self.file_load_recent_menu = QtWidgets.QMenu("Load Recent", self)

--- a/mkdd_editor.py
+++ b/mkdd_editor.py
@@ -664,7 +664,8 @@ class GenEditor(QtWidgets.QMainWindow):
         self.snapping_toggle_shortcut = QtGui.QShortcut(QtGui.QKeySequence(QtCore.Qt.Key_V), self)
         self.snapping_toggle_shortcut.activated.connect(self.level_view.toggle_snapping)
         self.snapping_cycle_shortcut = QtGui.QShortcut(
-            QtGui.QKeySequence(QtCore.Qt.Key_V | QtCore.Qt.SHIFT), self)
+            QtGui.QKeySequence(QtCore.QKeyCombination(QtCore.Qt.ShiftModifier, QtCore.Qt.Key_V)),
+            self)
         self.snapping_cycle_shortcut.activated.connect(self.level_view.cycle_snapping_mode)
 
         QtGui.QShortcut(QtGui.QKeySequence(QtCore.Qt.Key_G), self).activated.connect(self.action_ground_objects)
@@ -685,7 +686,9 @@ class GenEditor(QtWidgets.QMainWindow):
         self.file_menu = QtWidgets.QMenu(self)
         self.file_menu.setTitle("File")
 
-        save_file_shortcut = QtGui.QShortcut(QtCore.Qt.CTRL | QtCore.Qt.Key_S, self.file_menu)
+        save_file_shortcut = QtGui.QShortcut(
+            QtGui.QKeySequence(QtCore.QKeyCombination(QtCore.Qt.ControlModifier, QtCore.Qt.Key_V)),
+            self.file_menu)
         save_file_shortcut.activated.connect(self.button_save_level)
         #QtGui.QShortcut(QtCore.Qt.CTRL + QtCore.Qt.Key_O, self.file_menu).activated.connect(self.button_load_level)
         #QtGui.QShortcut(QtCore.Qt.CTRL + QtCore.Qt.Key_Alt + QtCore.Qt.Key_S, self.file_menu).activated.connect(self.button_save_level_as)

--- a/mkdd_editor.py
+++ b/mkdd_editor.py
@@ -664,7 +664,7 @@ class GenEditor(QtWidgets.QMainWindow):
         self.snapping_toggle_shortcut = QtGui.QShortcut(QtGui.QKeySequence(QtCore.Qt.Key_V), self)
         self.snapping_toggle_shortcut.activated.connect(self.level_view.toggle_snapping)
         self.snapping_cycle_shortcut = QtGui.QShortcut(
-            QtGui.QKeySequence(QtCore.Qt.Key_V | QtCore.Qt.Key_Shift), self)
+            QtGui.QKeySequence(QtCore.Qt.Key_V | QtCore.Qt.SHIFT), self)
         self.snapping_cycle_shortcut.activated.connect(self.level_view.cycle_snapping_mode)
 
         QtGui.QShortcut(QtGui.QKeySequence(QtCore.Qt.Key_G), self).activated.connect(self.action_ground_objects)
@@ -685,7 +685,7 @@ class GenEditor(QtWidgets.QMainWindow):
         self.file_menu = QtWidgets.QMenu(self)
         self.file_menu.setTitle("File")
 
-        save_file_shortcut = QtGui.QShortcut(QtCore.Qt.Key_Control | QtCore.Qt.Key_S, self.file_menu)
+        save_file_shortcut = QtGui.QShortcut(QtCore.Qt.CTRL | QtCore.Qt.Key_S, self.file_menu)
         save_file_shortcut.activated.connect(self.button_save_level)
         #QtGui.QShortcut(QtCore.Qt.CTRL + QtCore.Qt.Key_O, self.file_menu).activated.connect(self.button_load_level)
         #QtGui.QShortcut(QtCore.Qt.CTRL + QtCore.Qt.Key_Alt + QtCore.Qt.Key_S, self.file_menu).activated.connect(self.button_save_level_as)

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,5 +3,7 @@ numba==0.57.1
 numpy==1.24.2
 Pillow==10.0.1
 PyOpenGL==3.1.6
-PySide6==6.2.4
-shiboken6==6.2.4
+PySide6==6.5.3
+PySide6-Addons==6.5.3
+PySide6-Essentials==6.5.3
+shiboken6==6.5.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,8 @@
-llvmlite==0.40.1
-numba==0.57.1
-numpy==1.24.2
-Pillow==10.0.1
-PyOpenGL==3.1.6
+llvmlite==0.41.1
+numba==0.58.1
+numpy==1.26.2
+Pillow==10.1.0
+PyOpenGL==3.1.7
 PySide6==6.5.3
 PySide6-Addons==6.5.3
 PySide6-Essentials==6.5.3

--- a/setup.bat
+++ b/setup.bat
@@ -11,9 +11,7 @@ python -m venv venv
 call venv/Scripts/activate.bat
 
 rem Install cx_Freeze and its dependencies.
-python -m pip install cx-Freeze==6.14.9
-python -m pip install cx-Logging==3.1.0
-python -m pip install lief==0.12.3
+python -m pip install cx-Freeze==6.15.10 cx-Logging==3.1.0 lief==0.13.2
 
 rem Retrieve a fresh checkout from the repository to avoid a potentially
 rem polluted local checkout.


### PR DESCRIPTION
- Qt 6.5.3 LTS is now used, as Qt 6.2.4 LTS is no longer offered in PyPI for newer Python versions.
- The rest of the Python requirements have been bumped up to their latest versions.