### PR TITLE
Properly dismiss key presses in viewer if not focused.

### DIFF
--- a/mkdd_editor.py
+++ b/mkdd_editor.py
@@ -2835,10 +2835,11 @@ class GenEditor(QtWidgets.QMainWindow):
         self.set_has_unsaved_changes(True)
 
     def keyPressEvent(self, event: QtGui.QKeyEvent):
-        if event.key() == QtCore.Qt.Key_Plus:
-            self.level_view.zoom_in()
-        elif event.key() == QtCore.Qt.Key_Minus:
-            self.level_view.zoom_out()
+        if self.level_view.focused:
+            if event.key() == QtCore.Qt.Key_Plus:
+                self.level_view.zoom_in()
+            elif event.key() == QtCore.Qt.Key_Minus:
+                self.level_view.zoom_out()
 
         if event.isAutoRepeat():
             return
@@ -2851,21 +2852,22 @@ class GenEditor(QtWidgets.QMainWindow):
 
             self.update_3d()
 
-        if event.key() == QtCore.Qt.Key_Shift:
-            self.level_view.shift_is_pressed = True
+        if self.level_view.focused:
+            if event.key() == QtCore.Qt.Key_Shift:
+                self.level_view.shift_is_pressed = True
 
-        if event.key() == QtCore.Qt.Key_W:
-            self.level_view.MOVE_FORWARD = 1
-        elif event.key() == QtCore.Qt.Key_S:
-            self.level_view.MOVE_BACKWARD = 1
-        elif event.key() == QtCore.Qt.Key_A:
-            self.level_view.MOVE_LEFT = 1
-        elif event.key() == QtCore.Qt.Key_D:
-            self.level_view.MOVE_RIGHT = 1
-        elif event.key() == QtCore.Qt.Key_Q:
-            self.level_view.MOVE_UP = 1
-        elif event.key() == QtCore.Qt.Key_E:
-            self.level_view.MOVE_DOWN = 1
+            if event.key() == QtCore.Qt.Key_W:
+                self.level_view.MOVE_FORWARD = 1
+            elif event.key() == QtCore.Qt.Key_S:
+                self.level_view.MOVE_BACKWARD = 1
+            elif event.key() == QtCore.Qt.Key_A:
+                self.level_view.MOVE_LEFT = 1
+            elif event.key() == QtCore.Qt.Key_D:
+                self.level_view.MOVE_RIGHT = 1
+            elif event.key() == QtCore.Qt.Key_Q:
+                self.level_view.MOVE_UP = 1
+            elif event.key() == QtCore.Qt.Key_E:
+                self.level_view.MOVE_DOWN = 1
 
     def keyReleaseEvent(self, event: QtGui.QKeyEvent):
         if event.isAutoRepeat():

--- a/mkdd_widgets.py
+++ b/mkdd_widgets.py
@@ -114,6 +114,7 @@ class BolMapViewer(QtOpenGLWidgets.QOpenGLWidget):
         self.highlight_colltype = None
         self.cull_faces = False
 
+        self.focused = False
         self.shift_is_pressed = False
         self.last_mouse_move = None
 
@@ -250,8 +251,13 @@ class BolMapViewer(QtOpenGLWidgets.QOpenGLWidget):
                          GL_FLOAT, None)
             glBindTexture(GL_TEXTURE_2D, 0)
 
+    def focusInEvent(self, event: QtGui.QFocusEvent):
+        super().focusInEvent(event)
+        self.focused = True
+
     def focusOutEvent(self, event: QtGui.QFocusEvent):
         super().focusOutEvent(event)
+        self.focused = False
         self.editor.reset_move_flags()
 
     @catch_exception


### PR DESCRIPTION
A previous attempt at fixing it was applied in c6acc8f9bcea7d0ec8039de. However, there were still cases in which the viewer could receive an unmatched key press, leaving the viewer in infinite motion.

Test plan:

- Launch the MKDD Track Editor.
- Click on the **File** top-bar menu.
- While the menu is still deployed, press (and release) the `W` key.
- Dismiss the menu.

Without the change, the viewer camera would forever move up until `W` is pressed again (or the viewer loses focus).

With the change, the viewer camera won't accept key presses while the top-bar menu is deployed.