### PR TITLE
Draw cylindrical areas as wireframe cylinders.

### DIFF
--- a/lib/object_models.py
+++ b/lib/object_models.py
@@ -142,6 +142,16 @@ class ObjectModels(object):
         self.wireframe_cube.render()
         glPopMatrix()
 
+    def draw_wireframe_cylinder(self, position, rotation, scale):
+        glPushMatrix()
+        glTranslatef(position.x, -position.z, position.y)
+        mtx = rotation.mtx
+        glMultMatrixf(mtx)
+        glTranslatef(0.0, 0.0, scale.y / 2.0)
+        glScalef(-scale.z, scale.x, scale.y)
+        self.unitcylinder.render()
+        glPopMatrix()
+
     def draw_cylinder_last_position(self, radius, height):
         glPushMatrix()
 

--- a/mkdd_widgets.py
+++ b/mkdd_widgets.py
@@ -1366,7 +1366,10 @@ class BolMapViewer(QtOpenGLWidgets.QOpenGLWidget):
                     else:
                         glColor4f(*colors_area)
 
-                    self.models.draw_wireframe_cube(object.position, object.rotation, object.scale*100)
+                    draw_func = (self.models.draw_wireframe_cube
+                                 if object.shape == 0 else self.models.draw_wireframe_cylinder)
+                    draw_func(object.position, object.rotation, object.scale * 100)
+
             if vismenu.cameras.is_visible():
                 for object in self.level_file.cameras:
                     if object.name == "para":

--- a/widgets/data_editor.py
+++ b/widgets/data_editor.py
@@ -1231,6 +1231,7 @@ class AreaEdit(DataEditor):
                                                        MIN_SIGNED_SHORT, MAX_SIGNED_SHORT)
         set_tool_tip(self.lightparam_index, ttl.areadata['LightParam Index'])
 
+        self.shape.currentIndexChanged.connect(lambda _index: self.catch_text_update())
         self.area_type.currentTextChanged.connect(self.update_name)
 
     def update_data(self):


### PR DESCRIPTION
Previously, a cube was used for all area shapes. A cylinder is now used when `shape` is set to `1` (a.k.a. "cylinder").

Demo of the change in a cylindrical area in Yoshi Circuit:

| Before | After |
| --- | --- |
| ![MKDD Track Editor - Cylindrical Areas (before)](https://github.com/RenolY2/mkdd-track-editor/assets/1853278/d7e6a326-7207-4359-ad3b-6c790c94dbd0) | ![MKDD Track Editor - Cylindrical Areas (after)](https://github.com/RenolY2/mkdd-track-editor/assets/1853278/161124a4-12b9-4d50-89d8-0d15a2079acf) |