### PR TITLE
Document the `TTestString` object type (lifebuoy swing).

### DIFF
--- a/object_parameters/TTestString.json
+++ b/object_parameters/TTestString.json
@@ -1,8 +1,8 @@
 {
     "Object Parameters": [
-        "Unknown 1",
-        "Unknown 2",
-        "Unknown 3",
+        "Rope Segments",
+        "Rope Length",
+        "Simple Build",
         "Unused",
         "Unused",
         "Unused",
@@ -10,7 +10,20 @@
         "Unused"
     ],
     "Assets": [
+        "testhimo1.bmd",
+        "testhimo1shadow.bmd",
+        "testhimo1tex.bti",
         "testhimo1ukiwa.bmd"
+    ],
+    "Tooltips": [
+        "If not set to a value greater than `2`, the value is automatically overridden to `5`.",
+        "If not set to a value greater than `0`, the value is automatically overridden to `1000`.",
+        "If checked (default), the rope is built with a simpler segment chain.",
+        "",
+        "",
+        "",
+        "",
+        ""
     ],
     "RouteInfo": "None",
     "DefaultValues": [
@@ -22,5 +35,15 @@
         0,
         0,
         0
+    ],
+    "Widgets": [
+        null,
+        null,
+        "checkbox",
+        null,
+        null,
+        null,
+        null,
+        null
     ]
 }


### PR DESCRIPTION
The three values are read respectively from:

- **Rope Segments**: `0x8026B878` (in `TestString::__ct()`)
- **Rope Length**: `0x8026B894` (in `TestString::__ct()`)
- **Simple Build**: `0x8026BB2C` (in `TTestString::reset()`)

It is not entirely clear what the checkable flag does. Empirically, the behavior difference is quite subtle. The only obvious difference is that the logic that builds the segment chain is more complex when the flag is _not_ checked.