### PR TITLE
Unit tests for the `libbol` module.

### DIFF
--- a/lib/libbol.py
+++ b/lib/libbol.py
@@ -1549,7 +1549,11 @@ class BOL(object):
                 return route, route.points.index(point)
         return None, None
 
-with open("lib/mkddobjects.json", "r") as f:
+
+script_path = os.path.realpath(__file__)
+script_dir = os.path.dirname(script_path)
+
+with open(os.path.join(script_dir, 'mkddobjects.json'), 'r', encoding='utf-8') as f:
     tmp = json.load(f)
     OBJECTNAMES = {}
     for key, val in tmp.items():
@@ -1563,7 +1567,7 @@ valpairs.sort(key=lambda x: x[1])
 for key, val in valpairs:
     REVERSEOBJECTNAMES[OBJECTNAMES[key]] = key
 
-with open("lib/music_ids.json", "r") as f:
+with open(os.path.join(script_dir, 'music_ids.json'), 'r', encoding='utf-8') as f:
     tmp = json.load(f)
     MUSIC_IDS = {}
     for key, val in tmp.items():

--- a/lib/libbol_test.py
+++ b/lib/libbol_test.py
@@ -1,0 +1,64 @@
+"""
+Unit tests for the `libbol` module.
+"""
+import os
+import tempfile
+
+import pytest
+
+from . import libbol
+from . import rarc
+
+
+def _source_arc_filepaths() -> list[str]:
+    if not os.getenv('COURSES_TEST_DATA_SET_DIR'):
+        pytest.fail('COURSES_TEST_DATA_SET_DIR environment variable not set. A path to a directory '
+                    'containing the stock `.arc` course files must be provided.')
+    data_set_dir = os.environ['COURSES_TEST_DATA_SET_DIR']
+    if not os.path.isdir(data_set_dir):
+        pytest.fail(f'"{data_set_dir}" is not a valid directory.')
+
+    filepaths = []
+    for dirpath, dirnames, filenames in os.walk(data_set_dir):
+        dirnames.sort()
+        for filename in sorted(filenames):
+            if filename.endswith('.arc'):
+                filepath = os.path.join(dirpath, filename)
+                filepaths.append(filepath)
+    if not filepaths:
+        pytest.fail(f'No `.arc` file could be sourced from "{data_set_dir}".')
+    return filepaths
+
+
+def _get_bol_file(arc_filepath: str) -> bytes:
+    """
+    Unpacks the RARC file given its filepath, and reads the BOL file, if present.
+    """
+    with open(arc_filepath, "rb") as f:
+        archive = rarc.Archive.from_file(f)
+
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        archive.extract_to(tmp_dir)
+
+        for dirpath, _dirnames, filenames in os.walk(tmp_dir):
+            for filename in filenames:
+                if filename.endswith('.bol'):
+                    filepath = os.path.join(dirpath, filename)
+                    with open(filepath, 'rb') as f:
+                        return f.read()
+
+    return bytes()
+
+
+@pytest.mark.parametrize("arc_filepath", _source_arc_filepaths())
+def test_stock_data_set(arc_filepath):
+    original_data = _get_bol_file(arc_filepath)
+    assert original_data
+
+    bol = libbol.BOL.from_bytes(original_data)
+    baked_data = bol.to_bytes()
+
+    original_length = len(original_data)
+    baked_length = len(baked_data)
+    assert original_length == baked_length
+    assert original_data == baked_data

--- a/lib/rarc.py
+++ b/lib/rarc.py
@@ -1,3 +1,4 @@
+import os
 from struct import pack, unpack
 from io import BytesIO
 from itertools import chain
@@ -585,7 +586,6 @@ class Archive(object):
 
 if __name__ == "__main__":
     import argparse
-    import os
 
     parser = argparse.ArgumentParser()
     parser.add_argument("input",


### PR DESCRIPTION
Basic coverage that unpacks all the stock `.arc` files in the game's `files/Course` directory, loading and saving their BOL files, and verifying that the saved BOL file matches the reference file byte to byte.

The path to the `files/Course` directory must be specified in the `COURSES_TEST_DATA_SET_DIR` environment variable.

Usage:

_**Linux**_
```shell
env COURSES_TEST_DATA_SET_DIR="/path/to/GM4E01/files/Course" && pytest lib/libbol_test.py
```
```
=================================== test session starts ===================================
platform linux -- Python 3.10.12, pytest-7.4.3, pluggy-1.3.0
rootdir: /w/mkdd-track-editor
collected 50 items

lib/libbol_test.py ..................................................                 [100%]

=================================== 50 passed in 0.29s ====================================
```

_**Windows**_
```bat
set "COURSES_TEST_DATA_SET_DIR=C:\path\to\GM4E01\files\Course"
pytest lib\libbol_test.py
```
```
=================================== test session starts ===================================
platform win32 -- Python 3.10.11, pytest-7.4.3, pluggy-1.3.0
rootdir: X:\mkdd-track-editor
collected 50 items

lib\libbol_test.py ..................................................                [100%]

=================================== 50 passed in 2.03s ====================================
```