### PR TITLE
Treat focus out event as potentially-editing event.

### DIFF
--- a/mkdd_editor.py
+++ b/mkdd_editor.py
@@ -3809,6 +3809,7 @@ class Application(QtWidgets.QApplication):
     def _on_focus_changed(self, old: QtWidgets.QWidget, now: QtWidgets.QWidget):
         _ = old, now
         self._pending_focus_change = True
+        QtCore.QTimer.singleShot(0, self.document_potentially_changed)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Previously, it was possible to capture parameter changes and selection changes within the same potentially-editing event.

Test plan:

- Load a course.
- Select an enemy path point.
- In the data editor, click in the **Scale** parameter spin box to gain focus.
- Without losing focus, change the value considerably (e.g. multiply by 3).
- Click in the viewport, which will:
  - Switch focus from the spin box to the viewport, which commits the change made to the spin box
  - Deselect the enemy path point as the viewport processes the mouse click

**Without** the fix, both actions are captured under the same undo entry; if the action is undone, there is no intermediate step in which the enemy path point is still selected but shows the _modified_ scale value.

**With** the fix, if the last action is undone, the enemy path point is re-selected, and the modified scale value is preserved; a second undo operation would be needed to also undo the scale value change.

(The workaround to this issue was to click somewhere other than in the viewport, so that the selection would not change concurrently with the parameter change).