### PR TITLE
Revise multi-selection data editor changes.

### DIFF
--- a/mkdd_editor.py
+++ b/mkdd_editor.py
@@ -474,6 +474,8 @@ class GenEditor(QtWidgets.QMainWindow):
 
                 self.error_analyzer_button.analyze_bol(self.level_file)
 
+                self.action_update_data_editor_label()
+
     def update_undo_redo_actions(self):
         self.undo_action.setEnabled(len(self.undo_history) > 1)
         self.redo_action.setEnabled(bool(self.redo_history))
@@ -3641,30 +3643,28 @@ class GenEditor(QtWidgets.QMainWindow):
 
     @catch_exception
     def action_update_info(self):
-        if self.level_file is not None:
-            selected = self.level_view.selected
-            objects = []
-            if len(selected) == 1:
-                currentobj = selected[0]
-                if isinstance(currentobj, Route):
-                    index = self.level_file.routes.index(currentobj)
-                    for object in self.level_file.objects.objects:
-                        if object.route == currentobj:
-                            objects.append(get_full_name(object.objectid))
-                    for i, camera in enumerate(self.level_file.cameras):
-                        if camera.route == currentobj:
-                            objects.append("Camera {0}".format(i))
-            else:
-                self.pik_control.reset_info("{0} objects selected".format(len(self.level_view.selected)))
-                self.pik_control.set_objectlist(selected)
+        self.action_update_data_editor_label()
+        self.pik_control.set_info(self.level_view.selected, self.update_3d)
+        self.pik_control.update_info()
 
-            viewer_toolbar = self.level_view.viewer_toolbar
-            viewer_toolbar.delete_button.setEnabled(self.can_delete_objects())
-            viewer_toolbar.ground_button.setEnabled(self.can_ground_objects())
-            viewer_toolbar.distribute_button.setEnabled(self.can_distribute_objects())
+        viewer_toolbar = self.level_view.viewer_toolbar
+        viewer_toolbar.delete_button.setEnabled(self.can_delete_objects())
+        viewer_toolbar.ground_button.setEnabled(self.can_ground_objects())
+        viewer_toolbar.distribute_button.setEnabled(self.can_distribute_objects())
 
-            self.pik_control.set_info(selected, self.update_3d, objects)
-            self.pik_control.update_info()
+    def action_update_data_editor_label(self):
+        usedby = []
+        selected = self.level_view.selected
+        if len(selected) == 1:
+            currentobj = selected[0]
+            if isinstance(currentobj, Route):
+                for obj in self.level_file.objects.objects:
+                    if obj.route == currentobj:
+                        usedby.append(get_full_name(obj.objectid))
+                for i, camera in enumerate(self.level_file.cameras):
+                    if camera.route == currentobj:
+                        usedby.append(f'Camera {i}')
+        self.pik_control.set_label(selected, usedby)
 
     @catch_exception
     def mapview_showcontextmenu(self, position):

--- a/widgets/data_editor.py
+++ b/widgets/data_editor.py
@@ -566,7 +566,7 @@ class DataEditor(QtWidgets.QWidget):
         return widget
 
     def update_rotation(self, forwardedits, upedits, leftedits):
-        rotation = get_average_obj(self.bound_to).rotation
+        rotation = self.average_rotation
         forward, up, left = rotation.get_vectors()
 
         for attr in ("x", "y", "z"):
@@ -597,6 +597,7 @@ class DataEditor(QtWidgets.QWidget):
 
     def add_rotation_input(self):
         rotation = get_average_obj(self.bound_to).rotation
+        self.average_rotation = rotation
         forward_spinboxes = []
         up_spinboxes = []
         left_spinboxes = []
@@ -621,6 +622,8 @@ class DataEditor(QtWidgets.QWidget):
             left.normalize()
 
             rotation.set_vectors(newforward, up, left)
+            for obj in self.bound_to:
+                obj.rotation.set_vectors(newforward, up, left)
             self.update_rotation(forward_spinboxes, up_spinboxes, left_spinboxes)
 
         def change_up():
@@ -635,6 +638,8 @@ class DataEditor(QtWidgets.QWidget):
             left.normalize()
 
             rotation.set_vectors(forward, newup, left)
+            for obj in self.bound_to:
+                obj.rotation.set_vectors(forward, newup, left)
             self.update_rotation(forward_spinboxes, up_spinboxes, left_spinboxes)
 
         def change_left():
@@ -650,6 +655,8 @@ class DataEditor(QtWidgets.QWidget):
             up.normalize()
 
             rotation.set_vectors(forward, up, newleft)
+            for obj in self.bound_to:
+                obj.rotation.set_vectors(forward, up, newleft)
             self.update_rotation(forward_spinboxes, up_spinboxes, left_spinboxes)
 
         for edit in forward_spinboxes:

--- a/widgets/data_editor.py
+++ b/widgets/data_editor.py
@@ -400,7 +400,8 @@ class DataEditor(QtWidgets.QWidget):
 
             tt_dict = getattr(ttl, attribute, {})
             if tt_dict:
-                combobox.setToolTip(tt_dict.get(item, ''))
+                combobox.setToolTip(
+                    tt_dict.get(item) or ttl.markdown_to_html(item, 'Description not available.'))
 
         combobox.currentTextChanged.connect(item_selected)
         self.vbox.addLayout(layout)
@@ -1128,6 +1129,9 @@ class ObjectEdit(DataEditor):
         index = self.objectid.findText(name)
         with QtCore.QSignalBlocker(self.objectid):
             self.objectid.setCurrentIndex(index)
+
+        self.objectid.setToolTip(ttl.objectid.get(name)
+                                 or ttl.markdown_to_html(name, 'Description not available.'))
 
         #self.pathid.setValueQuiet(obj.pathid)
 


### PR DESCRIPTION
Fixes to address a number of minor regressions introduced in 7178d896693f4216be2abf1761e070531b8849ac:

- Ensure that the tool tip for the **Object Type** parameter is set as soon as the widget is created. Otherwise the tool tip was only set when the combobox changed.
- Aggregate names of selected objects to show above the data editor. Names are now built taking into account object subtypes (for map objects and areas), as well as the name in cameras. If the subtype, or camera name, change, the label is rebuilt.
- Process changes in the rotation field in the data editor for all selected objects. This was an oversight in the aforementioned commit, where bound objects were not updated when the rotation changed.