### PR TITLE
 Add completer in combobox for object subtypes.

### DIFF
--- a/mkdd_editor.py
+++ b/mkdd_editor.py
@@ -3798,8 +3798,10 @@ class Application(QtWidgets.QApplication):
             if isinstance(receiver, QtGui.QWindow):
                 # Certain widget types are known to submit many value changes while they have focus.
                 # Potentially-editing events will be disregarded until focus is out (unless there
-                # have been a recent focus change)
-                disregardable = isinstance(self.focusWidget(), QtWidgets.QAbstractSpinBox)
+                # have been a recent focus change). Equally, auto-repeating keys are disregarded.
+                disregardable = (isinstance(self.focusWidget(), QtWidgets.QAbstractSpinBox)
+                                 or (event.type() == QtCore.QEvent.KeyRelease
+                                     and event.isAutoRepeat()))
                 if not disregardable or self._pending_focus_change:
                     self._pending_focus_change = False
                     QtCore.QTimer.singleShot(0, self.document_potentially_changed)

--- a/widgets/data_editor.py
+++ b/widgets/data_editor.py
@@ -193,6 +193,60 @@ class ClickableLabel(QtWidgets.QLabel):
             self.clicked.emit()
 
 
+class CompleterComboBox(QtWidgets.QComboBox):
+
+    item_changed = QtCore.Signal(str)
+
+    def __init__(self, bound_to, attribute, keyval_dict, parent: QtWidgets.QWidget = None):
+        super().__init__(parent=parent)
+
+        policy = self.sizePolicy()
+        policy.setHorizontalPolicy(QtWidgets.QSizePolicy.Expanding)
+        self.setSizePolicy(policy)
+        self.setSizeAdjustPolicy(QtWidgets.QComboBox.AdjustToMinimumContentsLengthWithIcon)
+
+        for val in keyval_dict:
+            self.addItem(val)
+
+        self.setInsertPolicy(QtWidgets.QComboBox.NoInsert)
+        self.setEditable(True)
+        lineedit = self.lineEdit()
+
+        def on_editingFinished():
+            key = lineedit.text()
+            if key not in keyval_dict:
+                # It may be a partial match in the completer. If not a valid key, revert back to
+                # the key based on the current value of the object.
+                obj = get_average_obj(bound_to)
+                value = getattr(obj, attribute)
+                for k, v in keyval_dict.items():
+                    if v == value:
+                        key = k
+                        break
+                else:
+                    return
+
+            lineedit.setText(key)
+            self.setCurrentText(key)
+            self.item_changed.emit(key)
+
+        lineedit.editingFinished.connect(on_editingFinished)
+
+        completer = QtWidgets.QCompleter(sorted(keyval_dict), self)
+        completer.setCaseSensitivity(QtCore.Qt.CaseInsensitive)
+        completer.setFilterMode(QtCore.Qt.MatchContains)
+
+        max_visible_items = min(30, len(keyval_dict))
+        completer.setMaxVisibleItems(max_visible_items)
+        self.setMaxVisibleItems(max_visible_items)
+
+        completer.activated[str].connect(self.item_changed)
+        self.currentIndexChanged.connect(
+            lambda index: self.item_changed.emit(list(keyval_dict)[index]))
+
+        lineedit.setCompleter(completer)
+
+
 class ColorPicker(ClickableLabel):
 
     color_changed = QtCore.Signal(QtGui.QColor)
@@ -403,6 +457,26 @@ class DataEditor(QtWidgets.QWidget):
                 combobox.setToolTip(tt_dict.get(item, ''))
 
         combobox.currentTextChanged.connect(item_selected)
+        self.vbox.addLayout(layout)
+
+        return combobox
+
+    def add_completer_dropdown_input(self, text, attribute, keyval_dict):
+        combobox = CompleterComboBox(self.bound_to, attribute, keyval_dict, self)
+
+        layout = self.create_labeled_widget(self, text, combobox)
+
+        def on_item_selected(item):
+            val = keyval_dict[item]
+            for obj in self.bound_to:
+                setattr(obj, attribute, val)
+
+            tt_dict = getattr(ttl, attribute, {})
+            if tt_dict:
+                combobox.setToolTip(
+                    tt_dict.get(item) or ttl.markdown_to_html(item, 'Description not available.'))
+
+        combobox.item_changed.connect(on_item_selected)
         self.vbox.addLayout(layout)
 
         return combobox
@@ -996,7 +1070,8 @@ class ObjectEdit(DataEditor):
         for spinbox in self.scale:
             spinbox.setSingleStep(0.1)
         self.rotation = self.add_rotation_input()
-        self.objectid = self.add_dropdown_input("Object Type", "objectid", REVERSEOBJECTNAMES)
+        self.objectid = self.add_completer_dropdown_input("Object Type", "objectid",
+                                                          REVERSEOBJECTNAMES)
         self.prev_objectname = None
 
         #self.pathid = self.add_integer_input("Route ID", "pathid",
@@ -1044,12 +1119,12 @@ class ObjectEdit(DataEditor):
         self.userdata_layout = QtWidgets.QVBoxLayout()
         self.vbox.addLayout(self.userdata_layout)
 
-        self.objectid.currentTextChanged.connect(self.update_name)
+        self.objectid.item_changed.connect(lambda _item: self.update_name())
 
         for widget in self.position:
             widget.valueChanged.connect(lambda _value: self.catch_text_update())
 
-        self.objectid.currentTextChanged.connect(self.rebuild_object_parameters_widgets)
+        self.objectid.item_changed.connect(self.rebuild_object_parameters_widgets)
 
         self.assets = QtWidgets.QLineEdit()
         self.assets.setReadOnly(True)

--- a/widgets/side_widget.py
+++ b/widgets/side_widget.py
@@ -44,8 +44,6 @@ class PikminSideWidget(QtWidgets.QWidget):
         self.scroll_area_frame_layout.addWidget(self.comment_label)
         self.comment_label.hide()
 
-        self.scroll_area_frame_layout.addStretch()
-
         # Data editor.
         self.object_data_edit = None
 
@@ -87,8 +85,8 @@ class PikminSideWidget(QtWidgets.QWidget):
         if editor is not None:
             bol = self.boleditor.level_file
             self.object_data_edit = editor(self, bol, objs)
-            self.scroll_area_frame_layout.insertWidget(self.scroll_area_frame_layout.count() - 1,
-                                                       self.object_data_edit)
+            self.object_data_edit.layout().addStretch()
+            self.scroll_area_frame_layout.addWidget(self.object_data_edit)
             self.object_data_edit.emit_3d_update.connect(update3d)
 
         self.comment_label.setText("")


### PR DESCRIPTION
The number of object types is overwhelming, and it was difficult to find any specific type without aid.

Demo:

![MKDD Track Editor - Completer for object subtypes](https://github.com/RenolY2/mkdd-track-editor/assets/1853278/0cbf37f0-ded2-4967-858e-867fb9b752da)