### PR TITLE
Find unique IDs for new enemy paths and checkpoint groups.

### DIFF
--- a/lib/libbol.py
+++ b/lib/libbol.py
@@ -501,7 +501,13 @@ class EnemyPointGroups(object):
             for point in group.points:
                 yield point
 
+    def used_ids(self) -> set[int]:
+        return set(group.id for group in self.groups)
+
     def new_group_id(self):
+        for i, used_id in enumerate(sorted(self.used_ids())):
+            if i != used_id:
+                return i
         return len(self.groups)
 
     def used_links(self):
@@ -752,7 +758,13 @@ class CheckpointGroups(object):
 
         return checkpointgroups
 
+    def used_ids(self) -> set[int]:
+        return set(group.grouplink for group in self.groups)
+
     def new_group_id(self):
+        for i, used_id in enumerate(sorted(self.used_ids())):
+            if i != used_id:
+                return i
         return len(self.groups)
 
     def points(self):


### PR DESCRIPTION
The previous implementation would greedily take the length of the list as the new ID, wrongly assuming that there would no gap in the list (only if there is no gap is the length of the list guaranteed to be unique).

The new implementation finds the first available group ID from to the length of the list.

The issue could manifest in rather obscure cases. For example:

- Launch the Editor.
- Add an enemy path and an enemy path point.
- Select the enemy path, and change its **Group ID** from `0` to `1`.
- While the enemy path is selected, press `Ctrl+C` to copy it.
- Press `Ctrl+V` to paste the enemy path.
- Deselect the current selection (e.g. by clicking on an empty space in the viewport).
- Press `Ctrl+Z` to undo the action.
- The following exception would be raised, leaving the Editor in an inconsistent state:

```
Traceback (most recent call last):
  File "./mkdd_editor.py", line 449, in on_undo_action_triggered
    self.load_top_undo_entry()
  File "./mkdd_editor.py", line 376, in load_top_undo_entry
    enemy_path = bol_enemy_paths.pop(0)
IndexError: pop from empty list
```