### PR TITLE
 Disallow manual input of duplicate IDs in enemy paths.

### DIFF
--- a/lib/libbol.py
+++ b/lib/libbol.py
@@ -409,6 +409,8 @@ class EnemyPointGroup(object):
         self.points = []
         self.id = 0
 
+        self.widget = None
+
     @classmethod
     def new(cls):
         return cls()
@@ -467,6 +469,7 @@ class EnemyPointGroup(object):
 
     def __iadd__(self, other):
         self.id = self.id if self.id == other.id else -1
+        return self
 
     def __itruediv__(self, count):
         return self

--- a/widgets/data_editor.py
+++ b/widgets/data_editor.py
@@ -1465,6 +1465,10 @@ class RespawnPointEdit(DataEditor):
         self.respawn_id = self.add_integer_input("Respawn ID", None,
                                                  MIN_UNSIGNED_SHORT, MAX_UNSIGNED_SHORT)
         self.respawn_id.setEnabled(len(self.bound_to) == 1)
+        self.respawn_id_hex = QtWidgets.QLineEdit()
+        self.respawn_id_hex.setReadOnly(True)
+        self.respawn_id_hex.setDisabled(True)
+        self.respawn_id.property('parent_layout').addWidget(self.respawn_id_hex)
         set_tool_tip(self.respawn_id, ttl.respawn['Respawn ID'])
         self.unk1 = self.add_integer_input("Next Enemy Point", "unk1",
                                            MIN_UNSIGNED_SHORT, MAX_UNSIGNED_SHORT)
@@ -1480,6 +1484,8 @@ class RespawnPointEdit(DataEditor):
         self.unk3.valueChanged.connect(lambda _value: self.catch_text_update())
 
         def on_valueChanged(value):
+            self.respawn_id_hex.setText(f'Hex: 0x{value:02X}')
+
             palette = self.respawn_id.palette()
 
             obj = self.bound_to[0]
@@ -1503,6 +1509,7 @@ class RespawnPointEdit(DataEditor):
             obj = self.bound_to[0]
             if obj.respawn_id != self.respawn_id.value():
                 self.respawn_id.setValue(obj.respawn_id)
+            self.respawn_id_hex.setText(f'Hex: 0x{obj.respawn_id:02X}')
 
         self.respawn_id.valueChanged.connect(on_valueChanged)
         self.respawn_id.editingFinished.connect(on_editingFinished)
@@ -1514,6 +1521,7 @@ class RespawnPointEdit(DataEditor):
         self.position[2].setValueQuiet(obj.position.z)
         self.update_rotation(*self.rotation)
         self.respawn_id.setValueQuiet(obj.respawn_id)
+        self.respawn_id_hex.setText(f'Hex: 0x{obj.respawn_id:02X}')
         self.unk1.setValueQuiet(obj.unk1)
         self.unk2.setValueQuiet(obj.unk2)
         self.unk3.setValueQuiet(obj.unk3)

--- a/widgets/data_editor.py
+++ b/widgets/data_editor.py
@@ -863,6 +863,7 @@ class EnemyPointEdit(DataEditor):
             if obj.widget is None:
                 continue
             obj.widget.update_name()
+            obj.widget.parent().update_name()
 
 
 class CheckpointGroupEdit(DataEditor):

--- a/widgets/data_editor.py
+++ b/widgets/data_editor.py
@@ -1455,8 +1455,9 @@ class RespawnPointEdit(DataEditor):
         self.position = self.add_multiple_decimal_input("Position", "position", ["x", "y", "z"],
                                                         -inf, +inf)
         self.rotation = self.add_rotation_input()
-        self.respawn_id = self.add_integer_input("Respawn ID", "respawn_id",
+        self.respawn_id = self.add_integer_input("Respawn ID", None,
                                                  MIN_UNSIGNED_SHORT, MAX_UNSIGNED_SHORT)
+        self.respawn_id.setEnabled(len(self.bound_to) == 1)
         set_tool_tip(self.respawn_id, ttl.respawn['Respawn ID'])
         self.unk1 = self.add_integer_input("Next Enemy Point", "unk1",
                                            MIN_UNSIGNED_SHORT, MAX_UNSIGNED_SHORT)
@@ -1471,8 +1472,26 @@ class RespawnPointEdit(DataEditor):
         set_tool_tip(self.unk3, ttl.respawn['Previous Checkpoint'])
         self.unk3.valueChanged.connect(lambda _value: self.catch_text_update())
 
+        def on_valueChanged(value):
+            obj = self.bound_to[0]
+            for i, respawn_point in enumerate(self.bol.respawnpoints):
+                if respawn_point is obj:
+                    continue
+                if respawn_point.respawn_id == value:
+                    print(f"Warning: Respawn point at index #{i} is already using ID {value}.")
+                    return
 
-        self.respawn_id.valueChanged.connect(lambda _value: self.update_name())
+            obj.respawn_id = value
+
+            self.update_name()
+
+        def on_editingFinished():
+            obj = self.bound_to[0]
+            if obj.respawn_id != self.respawn_id.value():
+                self.respawn_id.setValue(obj.respawn_id)
+
+        self.respawn_id.valueChanged.connect(on_valueChanged)
+        self.respawn_id.editingFinished.connect(on_editingFinished)
 
     def update_data(self):
         obj: JugemPoint = get_average_obj(self.bound_to)

--- a/widgets/data_editor.py
+++ b/widgets/data_editor.py
@@ -752,17 +752,24 @@ class EnemyPointGroupEdit(DataEditor):
         self.groupid.setEnabled(len(self.bound_to) == 1)
 
         def on_valueChanged(value):
+            palette = self.groupid.palette()
+
             obj = self.bound_to[0]
             for i, group in enumerate(self.bol.enemypointgroups.groups):
                 if group is obj:
                     continue
                 if group.id == value:
                     print(f"Warning: Enemy path at index #{i} is already using ID {value}.")
+                    palette.setColor(QtGui.QPalette.ColorRole.Highlight, QtCore.Qt.red)
+                    self.groupid.setPalette(palette)
                     return
 
             obj.id = value
             for enemypathpoint in obj.points:
                 enemypathpoint.group = value
+
+            palette.setColor(QtGui.QPalette.ColorRole.Highlight, self.palette().highlight().color())
+            self.groupid.setPalette(palette)
 
             self.update_name()
 
@@ -1473,15 +1480,22 @@ class RespawnPointEdit(DataEditor):
         self.unk3.valueChanged.connect(lambda _value: self.catch_text_update())
 
         def on_valueChanged(value):
+            palette = self.respawn_id.palette()
+
             obj = self.bound_to[0]
             for i, respawn_point in enumerate(self.bol.respawnpoints):
                 if respawn_point is obj:
                     continue
                 if respawn_point.respawn_id == value:
                     print(f"Warning: Respawn point at index #{i} is already using ID {value}.")
+                    palette.setColor(QtGui.QPalette.ColorRole.Highlight, QtCore.Qt.red)
+                    self.respawn_id.setPalette(palette)
                     return
 
             obj.respawn_id = value
+
+            palette.setColor(QtGui.QPalette.ColorRole.Highlight, self.palette().highlight().color())
+            self.respawn_id.setPalette(palette)
 
             self.update_name()
 

--- a/widgets/tree_view.py
+++ b/widgets/tree_view.py
@@ -210,7 +210,7 @@ class RespawnEntry(NamedItem):
     def update_name(self):
         for i in range(self.parent().childCount()):
             if self == self.parent().child(i):
-                self.setText(0, "Respawn Point {0} (ID: {1})".format(i, self.bound_to.respawn_id))
+                self.setText(0, "Respawn Point {0} (ID: {1} / 0x{1:02X})".format(i, self.bound_to.respawn_id))
                 break
 
 

--- a/widgets/tree_view.py
+++ b/widgets/tree_view.py
@@ -45,6 +45,7 @@ class ObjectGroupObjects(ObjectGroup):
 class EnemyPointGroup(ObjectGroup):
     def __init__(self, parent, bound_to):
         super().__init__("Enemy Path", parent=parent, bound_to=bound_to)
+        bound_to.widget = self
         self.update_name()
 
     def update_name(self):


### PR DESCRIPTION
The **Group ID** field in the data editor was not checking whether the value entered by the user was unique.

Furthermore, it was not updating the group ID in the child enemy path points, leaving the BOL document in an inconsistent state (at least temporarily).

Bonus: The tree view item is now updated as the ID changes in the data editor.

Bonus: Update also parent tree view item when the link value in an enemy path point changes. Otherwise the link label shown in the parent tree view item could show stale data until a different action would update the tree view.

Bonus: Same logic has been applied for respawn points.