### PR TITLE
Add **Adjust** button for adjusting next enemy path point in respawn points.

### DIFF
--- a/lib/libbol.py
+++ b/lib/libbol.py
@@ -1951,19 +1951,27 @@ class BOL(object):
         self.write(f)
         return f.getvalue()
 
-    def adjust_respawn_point(self, respawn_point: JugemPoint):
-        new_id = 0
-        used_ids = set(rsp.respawn_id for rsp in self.respawnpoints)
-        while new_id in used_ids:
-            new_id += 1
-        respawn_point.respawn_id = new_id
+    def adjust_respawn_point(self,
+                             respawn_point: JugemPoint,
+                             also_id: bool = True,
+                             also_rotation: bool = True):
+        if also_id:
+            used_ids = set(rsp.respawn_id for rsp in self.respawnpoints)
+            for i, used_id in enumerate(sorted(used_ids)):
+                if i != used_id:
+                    new_id = i
+                    break
+            else:
+                new_id = len(self.respawnpoints)
+            respawn_point.respawn_id = new_id
 
         try:
             point_index, enemy_point = self.enemypointgroups.find_closest_forward_point(
                 respawn_point.position)
             respawn_point.unk1 = point_index
-            respawn_point.rotation = Rotation.from_points_2D(respawn_point.position,
-                                                             enemy_point.position)
+            if also_rotation:
+                respawn_point.rotation = Rotation.from_points_2D(respawn_point.position,
+                                                                 enemy_point.position)
         except ValueError:
             pass
 

--- a/widgets/data_editor.py
+++ b/widgets/data_editor.py
@@ -346,6 +346,8 @@ class DataEditor(QtWidgets.QWidget):
         layout = self.create_labeled_widget(self, text, spinbox)
         self.vbox.addLayout(layout)
 
+        spinbox.setProperty('parent_layout', layout)
+
         return spinbox
 
     def add_decimal_input(self, text, attribute, min_val, max_val):
@@ -1428,6 +1430,25 @@ class RespawnPointEdit(DataEditor):
         set_tool_tip(self.respawn_id, ttl.respawn['Respawn ID'])
         self.unk1 = self.add_integer_input("Next Enemy Point", "unk1",
                                            MIN_UNSIGNED_SHORT, MAX_UNSIGNED_SHORT)
+
+        def on_partial_clicked():
+            for obj in self.bound_to:
+                self.bol.adjust_respawn_point(obj, also_id=False, also_rotation=False)
+            self.update_data()
+
+        def on_full_clicked():
+            for obj in self.bound_to:
+                self.bol.adjust_respawn_point(obj, also_id=False, also_rotation=True)
+            self.update_data()
+
+        adjust_menu = QtWidgets.QMenu(self)
+        adjust_partial = adjust_menu.addAction('Adjust next enemy point')
+        adjust_full = adjust_menu.addAction('Adjust next enemy point and rotation')
+        adjust_partial.triggered.connect(on_partial_clicked)
+        adjust_full.triggered.connect(on_full_clicked)
+        adjust_button = QtWidgets.QPushButton('Adjust')
+        adjust_button.setMenu(adjust_menu)
+        self.unk1.property('parent_layout').addWidget(adjust_button)
         set_tool_tip(self.unk1, ttl.respawn['Next Enemy Point'])
         self.unk1.valueChanged.connect(lambda _value: self.catch_text_update())
 


### PR DESCRIPTION
![MKDD Track Editor - Respawn Point Adjust Button](https://github.com/RenolY2/mkdd-track-editor/assets/1853278/384e87d6-60e7-4990-b913-b536242a8978)

The button allows users to adjust _existing_ respawn points. It reuses the already available functionality that is already applied when a new respawn point is added.