### PR TITLE
Stash camera route before making a deep copy of the camera.

### DIFF
--- a/lib/libbol.py
+++ b/lib/libbol.py
@@ -1442,13 +1442,17 @@ class Camera(PositionedObject):
 
         nextcam = self.nextcam
         self.nextcam = None
+        route = self.route
+        self.route = None
 
         try:
             new_object = deepcopy(self)
             new_object.nextcam = nextcam
+            new_object.route = route
         finally:
             self.widget = widget
             self.nextcam = nextcam
+            self.route = route
 
         return new_object
 


### PR DESCRIPTION
Otherwise the copied object has a brand-new instance of the route that does not equal any of the existing route objects in the BOL file.

This was a regression in 7178d896693f4216be2abf1761e070531b8849ac.

Test plan:

- Load, for example, Yoshi Circuit.
- Select a [replay] camera that has a route assigned (e.g. a type 101).

Without the fix, the **Route** parameter in the data editor always shows `None`.

With the fix, the correct route is shown in the **Route** parameter in the data editor.