### PR TITLE
Hide scale Z component field in cylindrical areas.

### DIFF
--- a/mkdd_widgets.py
+++ b/mkdd_widgets.py
@@ -1372,9 +1372,14 @@ class BolMapViewer(QtOpenGLWidgets.QOpenGLWidget):
                     else:
                         glColor4f(*colors_area)
 
-                    draw_func = (self.models.draw_wireframe_cube
-                                 if object.shape == 0 else self.models.draw_wireframe_cylinder)
-                    draw_func(object.position, object.rotation, object.scale * 100)
+                    if object.shape == 0:
+                        draw_func = self.models.draw_wireframe_cube
+                        scale = object.scale
+                    else:
+                        draw_func = self.models.draw_wireframe_cylinder
+                        scale = object.scale.copy()
+                        scale.z = scale.x
+                    draw_func(object.position, object.rotation, scale * 100)
 
             if vismenu.cameras.is_visible():
                 for object in self.level_file.cameras:

--- a/widgets/data_editor.py
+++ b/widgets/data_editor.py
@@ -1260,7 +1260,10 @@ class AreaEdit(DataEditor):
         set_tool_tip(self.lightparam_index, ttl.areadata['LightParam Index'])
 
         self.shape.currentIndexChanged.connect(lambda _index: self.catch_text_update())
+        self.shape.currentIndexChanged.connect(lambda index: self.scale[2].setVisible(index == 0))
         self.area_type.currentTextChanged.connect(self.update_name)
+        self.scale[0].valueChanged.connect(
+            lambda value: self.scale[2].isHidden() and self.scale[2].setValue(value))
 
     def update_data(self):
         obj: Area = get_average_obj(self.bound_to)
@@ -1271,6 +1274,7 @@ class AreaEdit(DataEditor):
         self.scale[0].setValueQuiet(obj.scale.x)
         self.scale[1].setValueQuiet(obj.scale.y)
         self.scale[2].setValueQuiet(obj.scale.z)
+        self.scale[2].setVisible(obj.shape == 0)
 
         self.update_rotation(*self.rotation)
 


### PR DESCRIPTION
The game (see `Course::Area::check()`) only checks the squared Euclidean distance using the squared X component, disregarding the Z component.

The field is now hidden in the data editor when the area shape is set to `Cylinder`, and Z component is also ignored when the area is drawn in the viewport.