### PR TITLE
Explicitly define text color for tool tips.

### DIFF
--- a/mkdd_editor.py
+++ b/mkdd_editor.py
@@ -3879,6 +3879,7 @@ if __name__ == "__main__":
             padding: {padding}px;
             border: 1px solid rgb(32, 32, 32);
             background: rgb(40, 40, 40);
+            color: rgb(200, 200, 200);
         }}
     """)
 

--- a/mkdd_editor.py
+++ b/mkdd_editor.py
@@ -3877,8 +3877,8 @@ if __name__ == "__main__":
     app.setStyleSheet(f"""
         QToolTip {{
             padding: {padding}px;
-            border: 1px solid #202020;
-            background: #282828;
+            border: 1px solid rgb(32, 32, 32);
+            background: rgb(40, 40, 40);
         }}
     """)
 


### PR DESCRIPTION
On Windows, the text color was not inherited from the window text color as expected.