### PR TITLE
Revise keyboard modifier support in object selection in the viewer.

### DIFF
--- a/editor_controls.py
+++ b/editor_controls.py
@@ -133,8 +133,14 @@ class TopdownSelect(ClickDragAction):
         startz = min(selectstartz, selectendz)
         endz = max(selectstartz, selectendz)
 
-        editor.selectionqueue.queue_selection(int(startx), int(endz), int(endx - startx) + 1, int(endz - startz) + 1,
-                                       editor.shift_is_pressed)
+        editor.selectionqueue.queue_selection(
+            int(startx),
+            int(endz),
+            int(endx - startx) + 1,
+            int(endz - startz) + 1,
+            editor.shift_is_pressed,
+            editor.ctrl_is_pressed,
+        )
 
         editor.do_redraw(force=True)
 
@@ -150,8 +156,15 @@ class Gizmo2DMoveX(ClickDragAction):
         # the gizmo, we want the first press event to already make the gizmo handle interactive.
         # Therefore, the event is scheduled on the press event (instead of in the natural release
         # event).
-        editor.selectionqueue.queue_selection(event.x(), event.y(), 1, 1,
-                                              editor.shift_is_pressed, do_gizmo=True)
+        editor.selectionqueue.queue_selection(
+            event.x(),
+            event.y(),
+            1,
+            1,
+            editor.shift_is_pressed,
+            editor.ctrl_is_pressed,
+            do_gizmo=True,
+        )
         editor.do_redraw(force=True)
 
     def move(self, editor, buttons, event):
@@ -319,8 +332,14 @@ class Select3D(ClickDragAction):
         startz = min(selectstartz, selectendz)
         endz = max(selectstartz, selectendz)
 
-        editor.selectionqueue.queue_selection(int(startx), int(endz), int(endx - startx) + 1, int(endz - startz) + 1,
-                                       editor.shift_is_pressed)
+        editor.selectionqueue.queue_selection(
+            int(startx),
+            int(endz),
+            int(endx - startx) + 1,
+            int(endz - startz) + 1,
+            editor.shift_is_pressed,
+            editor.ctrl_is_pressed,
+        )
 
         editor.do_redraw(force=True)
 

--- a/mkdd_editor.py
+++ b/mkdd_editor.py
@@ -2964,6 +2964,8 @@ class GenEditor(QtWidgets.QMainWindow):
         if self.level_view.focused:
             if event.key() == QtCore.Qt.Key_Shift:
                 self.level_view.shift_is_pressed = True
+            if event.key() == QtCore.Qt.Key_Control:
+                self.level_view.ctrl_is_pressed = True
 
             if event.key() == QtCore.Qt.Key_W:
                 self.level_view.MOVE_FORWARD = 1
@@ -2984,6 +2986,8 @@ class GenEditor(QtWidgets.QMainWindow):
 
         if event.key() == QtCore.Qt.Key_Shift:
             self.level_view.shift_is_pressed = False
+        if event.key() == QtCore.Qt.Key_Control:
+            self.level_view.ctrl_is_pressed = False
 
         if event.key() == QtCore.Qt.Key_W:
             self.level_view.MOVE_FORWARD = 0
@@ -3006,6 +3010,7 @@ class GenEditor(QtWidgets.QMainWindow):
         self.level_view.MOVE_UP = 0
         self.level_view.MOVE_DOWN = 0
         self.level_view.shift_is_pressed = False
+        self.level_view.ctrl_is_pressed = False
 
     def action_rotate_object(self, deltarotation):
         #obj.set_rotation((None, round(angle, 6), None))

--- a/mkdd_editor.py
+++ b/mkdd_editor.py
@@ -2616,7 +2616,8 @@ class GenEditor(QtWidgets.QMainWindow):
                 selected_item.setSelected(False)
 
             # Make last item in the new selection current (focus effect), and select new items.
-            self.leveldatatreeview.setCurrentItem(new_item_selection[-1])
+            self.leveldatatreeview.setCurrentItem(new_item_selection[-1], 0,
+                                                  QtCore.QItemSelectionModel.ClearAndSelect)
             for bound_item in new_item_selection:
                 bound_item.setSelected(True)
 
@@ -3618,7 +3619,8 @@ class GenEditor(QtWidgets.QMainWindow):
                     self.leveldatatreeview.blockSignals(True)
 
                 if item is not None:
-                    self.leveldatatreeview.setCurrentItem(item)
+                    self.leveldatatreeview.setCurrentItem(item, 0,
+                                                          QtCore.QItemSelectionModel.ClearAndSelect)
                     self.level_view.selected_positions = selected_positions
 
                 if suppress_signal:


### PR DESCRIPTION
Previously, only the `Shift` modifier was supported for appending. Now, the following operations are supported:

| Operation                      | Modifiers                   |
|--------------------------------|-----------------------------|
| Replace selection              |                             |
| Append selected to selection   | `Shift` (marquee selection) |
| Toggle selected                | `Shift` (single click)      |
| Remove selected from selection | `Ctrl`                      |