### PR TITLE
Avoid occluding enemy path points with their scale spheres in the top-down view.

### DIFF
--- a/lib/object_models.py
+++ b/lib/object_models.py
@@ -115,6 +115,18 @@ class ObjectModels(object):
             self.sphere.render()
         glPopMatrix()
 
+    def draw_squashed_sphere(self, position, scale, solid=False):
+        glPushMatrix()
+
+        glTranslatef(position.x, -position.z, position.y)
+        glScalef(scale, scale, 0.0)
+
+        if solid:
+            self.sphere_solid.render()
+        else:
+            self.sphere.render()
+        glPopMatrix()
+
     def draw_sphere_last_position(self, scale):
         glPushMatrix()
 

--- a/mkdd_widgets.py
+++ b/mkdd_widgets.py
@@ -1137,7 +1137,10 @@ class BolMapViewer(QtOpenGLWidgets.QOpenGLWidget):
                         if point in select_optimize:
                             group_selected = True
                             glColor3f(0.3, 0.3, 0.3)
-                            self.models.draw_sphere(point.position, point.scale)
+                            if self.mode == MODE_TOPDOWN:
+                                self.models.draw_squashed_sphere(point.position, point.scale)
+                            else:
+                                self.models.draw_sphere(point.position, point.scale)
 
                         if point_index in enemypoints_to_highlight:
                             glColor3f(1.0, 1.0, 0.0)


### PR DESCRIPTION
Scale spheres for enemy path points are now rendered as a squashed sphere so that the top of the sphere does not occlude the enemy point, which helps with visibility.

| Before | After |
| --- | --- |
| ![MKDD Track Editor - Enemy point scale sphere (before)](https://github.com/RenolY2/mkdd-track-editor/assets/1853278/37710412-91a3-4f2e-99aa-21128d8a93a6) | ![MKDD Track Editor - Enemy point scale sphere (before)](https://github.com/RenolY2/mkdd-track-editor/assets/1853278/4f0e7ec1-1712-41a8-82f8-e1ccab27944b) |

In the 3D view, the scale sphere is still a regular sphere.