### PR TITLE
 Add **Snapping > Set Height Offset** menu action.

### DIFF
--- a/editor_controls.py
+++ b/editor_controls.py
@@ -184,13 +184,17 @@ class Gizmo2DMoveXZ(Gizmo2DMoveX):
     def move(self, editor, buttons, event):
         if editor.gizmo.was_hit["middle"]:
             if editor.snapping_enabled and editor.collision is not None:
-                radius = 2*editor.zoom_factor
-                coords = editor.get_closest_snapping_point(event.x(), event.y(), is3d=False, radius=radius)
+                radius = 2 * editor.zoom_factor
+                coords = editor.get_closest_snapping_point(event.x(),
+                                                           event.y(),
+                                                           is3d=False,
+                                                           radius=radius)
                 if coords is not None:
-                    offset = editor.viewer_toolbar.heightoffset.value()
-                    newcoord = Vector3(coords.x, coords.y, coords.z + offset)
-                    coords = newcoord
-                    editor.move_points_to.emit(coords.x, coords.y, coords.z)
+                    editor.move_points_to.emit(
+                        coords.x,
+                        coords.y,
+                        coords.z + editor.editor.snapping_height_offset,
+                    )
                 return
 
             #editor.gizmo.set_render_axis(AXIS_X)
@@ -450,9 +454,11 @@ class Gizmo3DMove(Gizmo3DMoveX):
             if editor.snapping_enabled and editor.collision is not None:
                 radius = 25
                 coords = editor.get_closest_snapping_point(event.x(), event.y(), radius=radius)
-                offset = editor.viewer_toolbar.heightoffset.value()
-                newcoord = Vector3(coords.x, coords.y, coords.z+offset)
-                coords = newcoord
+                coords = Vector3(
+                    coords.x,
+                    coords.y,
+                    coords.z + editor.editor.snapping_height_offset,
+                )
             else:
                 coords = editor.get_3d_coordinates(event.x(), event.y()) #, planeheight=editor.gizmo.position.y)
 

--- a/mkdd_editor.py
+++ b/mkdd_editor.py
@@ -198,6 +198,8 @@ class GenEditor(QtWidgets.QMainWindow):
 
         self.collision_area_dialog = None
 
+        self.snapping_height_offset = 0
+
         self.current_coordinates = None
 
         self._window_title = ""
@@ -858,6 +860,11 @@ class GenEditor(QtWidgets.QMainWindow):
             action.setCheckable(True)
             action.setToolTip(snapping_menu_tool_tip)
             self.snapping_menu_action_group.addAction(action)
+        self.snapping_menu.addSeparator()
+        self.snapping_height_offset_action = self.snapping_menu.addAction(
+            'Set Height Offset (0 units)')
+        self.snapping_height_offset_action.triggered.connect(
+            self.on_snapping_height_offset_action_triggered)
 
         self.analyze_action = QtGui.QAction("Analyze for common mistakes", self)
         self.analyze_action.triggered.connect(self.analyze_for_mistakes)
@@ -1629,6 +1636,24 @@ class GenEditor(QtWidgets.QMainWindow):
 
     def on_snapping_menu_action_triggered(self):
         self.level_view.set_snapping_mode(self.sender().objectName())
+
+    def on_snapping_height_offset_action_triggered(self):
+        input_dialog = QtWidgets.QInputDialog(self)
+        input_dialog.setWindowTitle('Snapping Height Offset')
+        input_dialog.setLabelText('Height offset that is applied to the snapping point:')
+        input_dialog.setInputMode(QtWidgets.QInputDialog.IntInput)
+        input_dialog.setIntStep(10)
+        input_dialog.setIntRange(-10000, 10000)
+        input_dialog.setIntValue(self.snapping_height_offset)
+        input_dialog.setOkButtonText('Apply')
+        input_dialog.setCancelButtonText('Cancel')
+        for button in input_dialog.findChildren(QtWidgets.QPushButton):
+            button.setIcon(QtGui.QIcon())
+        accepted = input_dialog.exec()
+        if accepted:
+            value = input_dialog.intValue()
+            self.snapping_height_offset = value
+            self.snapping_height_offset_action.setText(f'Set Height Offset ({value} units)')
 
     def change_to_topdownview(self, checked):
         if checked:

--- a/widgets/viewer_toolbar.py
+++ b/widgets/viewer_toolbar.py
@@ -320,10 +320,10 @@ class ToolbarButton(QtWidgets.QPushButton):
         self.setAutoFillBackground(True)
 
         font_height = self.fontMetrics().height()
-        size = int(font_height * 2.2)
+        size = int(font_height * 2.0) // 2 * 2
         self.setFixedSize(size, size)
 
-        size = int(font_height * 1.5)
+        size = int(font_height * 1.4) // 2 * 2
         self.setIconSize(QtCore.QSize(size, size))
 
         tool_tip = tooltip_list.markdown_to_html(name, textwrap.dedent(_TOOL_TIPS.get(name, '')))
@@ -345,8 +345,9 @@ class ToolbarButton(QtWidgets.QPushButton):
                 width: 0px;
             }}
             QPushButton {{
-                background: #282828;
+                background: #303030;
                 {border_style}
+                border: 1px solid #242424;
             }}
             QPushButton:hover {{
                 background: #363636;
@@ -361,6 +362,7 @@ class ToolbarButton(QtWidgets.QPushButton):
             style_sheet += """
                 QPushButton:checked {
                     background: #0F4673;
+                    border: 1px solid #0C3B60;
                 }
                 QPushButton:checked:hover {
                     background: #1D517B;
@@ -375,6 +377,7 @@ class ToolbarButton(QtWidgets.QPushButton):
             style_sheet += """
                 QPushButton:checked {
                     background: #119A06;
+                    border: none;
                 }
                 QPushButton:checked:hover {
                     background: #28AD1E;

--- a/widgets/viewer_toolbar.py
+++ b/widgets/viewer_toolbar.py
@@ -477,12 +477,6 @@ class ViewerToolbar(QtWidgets.QWidget):
         self.snapping_button.setChecked(False)
         layout.addWidget(self.snapping_button)
 
-        self.heightoffset = QtWidgets.QSpinBox()
-        self.heightoffset.setValue(0)
-        self.heightoffset.setRange(-10000, 10000)
-        self.heightoffset.setSingleStep(100)
-        # layout.addWidget(self.heightoffset)
-
         layout.addSpacing(group_spacing)
 
         self.delete_button = ToolbarButton('Delete')


### PR DESCRIPTION
The offset is applied to the height of the snapping point.

![MKDD Track Editor - Snapping Height Offset (I)](https://github.com/RenolY2/mkdd-track-editor/assets/1853278/f8624917-cae2-405a-be31-0374312a9cea)

![MKDD Track Editor - Snapping Height Offset (II)](https://github.com/RenolY2/mkdd-track-editor/assets/1853278/4ea7d5da-90ec-4af3-81dc-304e141e1047)

Bonus:
- Background/border color for buttons in viewer toolbar have been tweaked to better distinguish them from dead zones.
- Further use of squared distances in `get_closest_point()` (similar to 0c7f47dca4).