### PR TITLE
Richer labels in tree view items for cameras and areas.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ lib/examples/*
 lib/temp/*
 editor_config.ini
 log.txt
+venv

--- a/lib/libbol.py
+++ b/lib/libbol.py
@@ -1,3 +1,4 @@
+import collections
 import functools
 import json
 import math
@@ -1753,6 +1754,32 @@ class BOL(object):
         objects.extend(self.mgentries)
 
         return objects
+
+    def get_intro_cameras(self) -> tuple[list[Camera], bool]:
+        start_camera = None
+        for camera in self.cameras:
+            if camera.startcamera:
+                start_camera = camera
+                break
+
+        intro_cameras = []
+        cycle_detected = False
+
+        while start_camera is not None:
+            if start_camera in intro_cameras:
+                cycle_detected = True
+                break
+            intro_cameras.append(start_camera)
+            start_camera = start_camera.nextcam
+
+        return intro_cameras, cycle_detected
+
+    def get_cameras_bound_to_areas(self) -> dict[Camera, list[int]]:
+        area_cameras = collections.defaultdict(list)
+        for i, area in enumerate(self.areas.areas):
+            if area.area_type == 0x01 and area.camera is not None:
+                area_cameras[area.camera].append(i)
+        return area_cameras
 
     @classmethod
     def from_file(cls, f):

--- a/lib/libbol.py
+++ b/lib/libbol.py
@@ -1163,14 +1163,14 @@ class KartStartPoints(object):
 # Areas
 
 AREA_TYPES = {
-    0: "Shadow",
-    1: "Camera",
-    2: "Ceiling",
-    3: "No Dead Zone",
-    4: "Unknown 1",
-    5: "Unknown 2",
-    6: "Sound Effect",
-    7: "Lighting",
+    0: "🌘 Shadow",
+    1: "🎥 Replay Camera",
+    2: "🔼 Ceiling",
+    3: "🚫 No Dead Zone",
+    4: "❓ Unknown 1",
+    5: "❓ Unknown 2",
+    6: "📢 Sound Effect",
+    7: "💡 Lighting",
 }
 
 REVERSE_AREA_TYPES = dict(zip(AREA_TYPES.values(), AREA_TYPES.keys()))

--- a/mkdd_editor.py
+++ b/mkdd_editor.py
@@ -3145,12 +3145,24 @@ class GenEditor(QtWidgets.QMainWindow):
             elif isinstance(obj, libbol.Area):
                 self.level_file.areas.areas.remove(obj)
             elif isinstance(obj, libbol.Camera):
+                for area in self.level_file.areas.areas:
+                    if area.camera is obj:
+                        area.camera = None
+                for camera in self.level_file.cameras:
+                    if camera.nextcam is obj:
+                        camera.nextcam = None
                 self.level_file.cameras.remove(obj)
             elif isinstance(obj, libbol.CheckpointGroup):
                 self.level_file.checkpoints.groups.remove(obj)
             elif isinstance(obj, libbol.EnemyPointGroup):
                 self.level_file.enemypointgroups.groups.remove(obj)
             elif isinstance(obj, libbol.Route):
+                for mapobj in self.level_file.objects.objects:
+                    if mapobj.route is obj:
+                        mapobj.route = None
+                for camera in self.level_file.cameras:
+                    if camera.route is obj:
+                        camera.route = None
                 self.level_file.routes.remove(obj)
             elif isinstance(obj, libbol.LightParam):
                 self.level_file.lightparams.remove(obj)

--- a/widgets/data_editor.py
+++ b/widgets/data_editor.py
@@ -1392,6 +1392,9 @@ class AreaEdit(DataEditor):
         self.scale[0].valueChanged.connect(
             lambda value: self.scale[2].isHidden() and self.scale[2].setValue(value))
 
+        self.area_type.currentTextChanged.connect(self.update_camera_names)
+        self.camera.currentTextChanged.connect(self.update_camera_names)
+
     def update_data(self):
         obj: Area = get_average_obj(self.bound_to)
         self.position[0].setValueQuiet(obj.position.x)
@@ -1433,6 +1436,13 @@ class AreaEdit(DataEditor):
             if obj.widget is None:
                 continue
             obj.widget.update_name()
+
+    def update_camera_names(self):
+        for area in self.bound_to:
+            if area.widget is None:
+                continue
+            area.widget.treeWidget().update_camera_names()
+            break
 
 
 CAMERA_TYPES = OrderedDict()
@@ -1496,6 +1506,9 @@ class CameraEdit(DataEditor):
         self.camtype.currentIndexChanged.connect(lambda _index: self.catch_text_update())
         self.camtype.currentTextChanged.connect(self.update_name)
 
+        self.startcamera.stateChanged.connect(self.update_all_names)
+        self.nextcam.currentTextChanged.connect(self.update_all_names)
+
     def update_data(self):
         obj: Camera = get_average_obj(self.bound_to)
         self.position[0].setValueQuiet(obj.position.x)
@@ -1543,10 +1556,19 @@ class CameraEdit(DataEditor):
         self.name.setText(obj.name)
 
     def update_name(self):
+        intro_cameras, _cycle_detected = self.bol.get_intro_cameras()
+        area_cameras = self.bol.get_cameras_bound_to_areas()
         for camera in self.bound_to:
             if camera.widget is None:
                 continue
-            camera.widget.update_name()
+            camera.widget.update_name(intro_cameras, area_cameras)
+
+    def update_all_names(self):
+        for camera in self.bound_to:
+            if camera.widget is None:
+                continue
+            camera.widget.treeWidget().update_camera_names()
+            break
 
 
 class RespawnPointEdit(DataEditor):

--- a/widgets/editor_widgets.py
+++ b/widgets/editor_widgets.py
@@ -151,6 +151,9 @@ class ErrorAnalyzer(QtWidgets.QDialog):
             cls.check_enemy_path_points(bol, write_line)
             cls.check_checkpoints(bol, write_line)
 
+        # Check cameras.
+        cls.check_cameras(bol, write_line)
+
         return lines
 
     @classmethod
@@ -242,6 +245,22 @@ class ErrorAnalyzer(QtWidgets.QDialog):
         if len(bol.mgentries) != 8:
             write_line(f'Battle stages should have 8 mini game params, but {len(bol.mgentries)} '
                        'params are present.')
+
+    @classmethod
+    def check_cameras(cls, bol, write_line):
+        start_cameras = tuple((i, c) for i, c in enumerate(bol.cameras) if c.startcamera)
+        if len(start_cameras) > 1:
+            start_cameras = ', '.join(f'Camera {i}' for i, _c in start_cameras)
+            write_line(f'More than one start camera for the intro sequence: {start_cameras}')
+
+        intro_cameras, cycle_detected = bol.get_intro_cameras()
+        if cycle_detected:
+            write_line('A cycle has been detected in the camera intro sequence.')
+        else:
+            for i, camera in enumerate(bol.cameras):
+                if camera.nextcam is not None and camera not in intro_cameras:
+                    write_line(f'Camera {i} is not in the intro sequence but has the next camera '
+                               'field set.')
 
 
 def check_checkpoints(c1, c2):

--- a/widgets/editor_widgets.py
+++ b/widgets/editor_widgets.py
@@ -151,6 +151,9 @@ class ErrorAnalyzer(QtWidgets.QDialog):
             cls.check_enemy_path_points(bol, write_line)
             cls.check_checkpoints(bol, write_line)
 
+        # Check areas.
+        cls.check_areas(bol, write_line)
+
         # Check cameras.
         cls.check_cameras(bol, write_line)
 
@@ -245,6 +248,13 @@ class ErrorAnalyzer(QtWidgets.QDialog):
         if len(bol.mgentries) != 8:
             write_line(f'Battle stages should have 8 mini game params, but {len(bol.mgentries)} '
                        'params are present.')
+
+    @classmethod
+    def check_areas(cls, bol, write_line):
+        for i, area in enumerate(bol.areas.areas):
+            if area.area_type != 0x01 and area.camera is not None:
+                write_line(
+                    f'Area {i} is not a {libbol.AREA_TYPES[0x01]} but the camera field is set.')
 
     @classmethod
     def check_cameras(cls, bol, write_line):

--- a/widgets/tree_view.py
+++ b/widgets/tree_view.py
@@ -190,7 +190,7 @@ class AreaEntry(NamedItem):
         bound_to.widget = self
 
     def update_name(self):
-        self.setText(0, AREA_TYPES[self.bound_to.area_type])
+        self.setText(0, f'{AREA_TYPES[self.bound_to.area_type]} {self.index}')
 
 
 class CameraEntry(NamedItem):
@@ -461,8 +461,8 @@ class LevelDataTreeView(QtWidgets.QTreeWidget):
         for kartpoint in boldata.kartpoints.positions:
             item = KartpointEntry(self.kartpoints, "Kartpoint", kartpoint)
 
-        for area in boldata.areas.areas:
-            item = AreaEntry(self.areas, "Area", area)
+        for i, area in enumerate(boldata.areas.areas):
+            item = AreaEntry(self.areas, "Area", area, i)
 
         for respawn in boldata.respawnpoints:
             item = RespawnEntry(self.respawnpoints, "Respawn", respawn)

--- a/widgets/tree_view.py
+++ b/widgets/tree_view.py
@@ -198,8 +198,29 @@ class CameraEntry(NamedItem):
         super().__init__(parent, name, bound_to, index)
         bound_to.widget = self
 
-    def update_name(self):
-        self.setText(0, "Camera {0} (Type: {1:03X})".format(self.index, self.bound_to.camtype))
+    def update_name(self, intro_cameras=None, area_cameras=None):
+        if intro_cameras is None or area_cameras is None:
+            bol = self.treeWidget().editor.level_file
+            intro_cameras, _cycle_detected = bol.get_intro_cameras()
+            area_cameras = bol.get_cameras_bound_to_areas()
+
+        camera = self.bound_to
+
+        camera_tags = ''
+        try:
+            intro_camera_index = intro_cameras.index(camera)
+            camera_tags += f' - Intro {intro_camera_index + 1}/{len(intro_cameras)}'
+        except ValueError:
+            pass
+        area_indexes = area_cameras.get(camera)
+        if area_indexes is not None:
+            if len(area_indexes) == 1:
+                camera_tags += f' - Replay Area: {area_indexes[0]}'
+            else:
+                area_indexes = ', '.join(str(i) for i in area_indexes)
+                camera_tags += f' - Replay Areas: {area_indexes}'
+
+        self.setText(0, f"Camera {self.index} ({camera.camtype:03X}){camera_tags}")
 
 
 class RespawnEntry(NamedItem):
@@ -566,3 +587,12 @@ class LevelDataTreeView(QtWidgets.QTreeWidget):
         self.cameras.bound_to = levelfile.cameras
         self.respawnpoints.bound_to = levelfile.respawnpoints
         self.lightparams.bound_to = levelfile.lightparams
+
+    def update_camera_names(self):
+        bol = self.editor.level_file
+        intro_cameras, _cycle_detected = bol.get_intro_cameras()
+        area_cameras = bol.get_cameras_bound_to_areas()
+        top_level_item = self.cameras
+        for i in range(top_level_item.childCount()):
+            tree_item = top_level_item.child(i)
+            tree_item.update_name(intro_cameras, area_cameras)


### PR DESCRIPTION
- Labels in the tree view now show whether cameras are intro cameras or replay cameras.
- Area types now include an emoji in their names.

| ![MKDD Track Editor - Emojis for Area Types](https://github.com/RenolY2/mkdd-track-editor/assets/1853278/d84afa0b-c20d-462b-b478-5f7238bc11e2) | ![MKDD Track Editor - Rich labels in camera tree widget items](https://github.com/RenolY2/mkdd-track-editor/assets/1853278/5d7016e3-c629-4c9a-9c87-466b3f61786a) |
| --- | --- |