### PR TITLE
Reset GL blend function to initial values.

### DIFF
--- a/lib/model_rendering.py
+++ b/lib/model_rendering.py
@@ -794,7 +794,7 @@ class Minimap(object):
 
         glColor4f(1.0, 1.0, 1.0, 1.0)
         glDisable(GL_BLEND)
-        glBlendFunc(GL_ZERO, GL_ONE)
+        glBlendFunc(GL_ONE, GL_ZERO)
         glEnable(GL_ALPHA_TEST)
 
     def copy(self):


### PR DESCRIPTION
The initial values for [`glBlendFunc()`](https://registry.khronos.org/OpenGL-Refpages/gl4/html/glBlendFunc.xhtml) are `GL_ONE` and `GL_ZERO` respectively. However, in `Minimap.render()`, the arguments had been wrongly reversed.

This oversight did not show any misbehavior until Qt 6.7, where certain elements (e.g. the grid) would no longer be drawn, and the selection functionality would break.

It is not known at this time what changed in Qt 6.7 that surfaced the issue.