### PR TITLE
Update rotation widgets in data editor on change.

### DIFF
--- a/widgets/data_editor.py
+++ b/widgets/data_editor.py
@@ -651,7 +651,7 @@ class DataEditor(QtWidgets.QWidget):
         return widget
 
     def update_rotation(self, forwardedits, upedits, leftedits):
-        rotation = self.average_rotation
+        rotation = get_average_obj(self.bound_to).rotation
         forward, up, left = rotation.get_vectors()
 
         for attr in ("x", "y", "z"):
@@ -682,7 +682,6 @@ class DataEditor(QtWidgets.QWidget):
 
     def add_rotation_input(self):
         rotation = get_average_obj(self.bound_to).rotation
-        self.average_rotation = rotation
         forward_spinboxes = []
         up_spinboxes = []
         left_spinboxes = []


### PR DESCRIPTION
When the selected object is rotated in the viewport, the rotation fields in the data editor should now be updated interactively.

This was a regression in 6f166010c72c602, where the object's rotation was wrongly cached when the widgets are created, totally overlooking that any potential update coming from the rotate manipulators in the viewport would be disregarded if the rotation is cached!