### PR TITLE
Connect signals and slots of mismatching signature via intermediate lambdas.

### DIFF
--- a/mkdd_editor.py
+++ b/mkdd_editor.py
@@ -747,12 +747,12 @@ class GenEditor(QtWidgets.QMainWindow):
         open_config_dir_action = QtGui.QAction('Open Configuration Directory...', self)
         quit_action = QtGui.QAction('Quit', self)
 
-        self.file_load_action.triggered.connect(self.button_load_level)
-        self.save_file_action.triggered.connect(self.button_save_level)
-        self.save_file_as_action.triggered.connect(self.button_save_level_as)
-        self.save_file_copy_as_action.triggered.connect(self.button_save_level_copy_as)
-        open_config_dir_action.triggered.connect(open_config_directory)
-        quit_action.triggered.connect(self.close)
+        self.file_load_action.triggered.connect(lambda: self.button_load_level())
+        self.save_file_action.triggered.connect(lambda: self.button_save_level())
+        self.save_file_as_action.triggered.connect(lambda: self.button_save_level_as())
+        self.save_file_copy_as_action.triggered.connect(lambda: self.button_save_level_copy_as())
+        open_config_dir_action.triggered.connect(lambda: open_config_directory())
+        quit_action.triggered.connect(lambda: self.close())
 
         self.file_menu.addAction(self.file_load_action)
         self.file_menu.addMenu(self.file_load_recent_menu)
@@ -1288,7 +1288,7 @@ class GenEditor(QtWidgets.QMainWindow):
             save_cfg(self.configuration)
 
     @catch_exception_with_dialog
-    def action_save_to_dol(self, val):
+    def action_save_to_dol(self):
         filepath, choosentype = QtWidgets.QFileDialog.getSaveFileName(
             self, "Save to File",
             self.pathsconfig["dol"],


### PR DESCRIPTION
Since PySide 6.7, these connections were considered ill-formed: when the `triggered(bool checked = false)` signal was connected to slots that had arguments with default values (but did not reserve one argument for the `checked` boolean argument), PySide would still connect the slot to the overloaded signal that is emitted with the boolean argument (as opposed to connecting the slot to the argument-less version, the behavior seen in PySide 6.6 and older).