### PR TITLE
Add GitHub Actions to generate build on Linux (x64) and Windows (x64).

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,89 @@
+name: 🔨 Build
+
+on:
+  push:
+    branches:
+      - master
+    tags:
+      - 'v[0-9]+.[0-9]+.[0-9]+'
+
+jobs:
+  build-windows:
+    runs-on: windows-2022
+    name: 🪟 Windows (x64)
+
+    steps:
+      - name: Check Out Code
+        uses: actions/checkout@v4
+
+      - name: Install Dependencies
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
+
+      - name: Build
+        run: |
+          # Create a virtual environment.
+          set PYTHONNOUSERSITE=1
+          set "PYTHONPATH="
+          python3 -m venv venv
+          venv/Scripts/activate.ps1
+
+          # Install dependencies.
+          python -m pip install -r requirements-build-windows.txt
+          python -m pip install -r requirements.txt
+
+          # Build the bundle.
+          python setup.py build
+        shell: powershell
+
+      - name: Set Artifact Name
+        id: set-artifact-name
+        run: echo "artifact_name=`ls build`" >> $GITHUB_OUTPUT
+        shell: bash
+
+      - name: Upload Build
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ steps.set-artifact-name.outputs.artifact_name }}
+          path: build/*
+
+  build-linux:
+    runs-on: ubuntu-22.04
+    name: 🐧 Linux (x64)
+
+    steps:
+      - name: Check Out Code
+        uses: actions/checkout@v4
+
+      - name: Install Dependencies
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
+
+      - name: Build
+        run: |
+          # Create a virtual environment.
+          export PYTHONNOUSERSITE=1
+          unset PYTHONPATH
+          python3 -m venv venv
+          source venv/bin/activate
+
+          # Install dependencies.
+          python -m pip install -r requirements-build-linux.txt
+          python -m pip install -r requirements.txt
+
+          # Build the bundle.
+          python setup.py build
+        shell: bash
+
+      - name: Set Artifact Name
+        id: set-artifact-name
+        run: echo "artifact_name=`ls build`" >> $GITHUB_OUTPUT
+        shell: bash
+
+      - name: Upload Build
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ steps.set-artifact-name.outputs.artifact_name }}
+          path: build/*

--- a/mkdd_editor.py
+++ b/mkdd_editor.py
@@ -55,7 +55,7 @@ from lib.game_visualizer import Game
 from lib.vectors import Vector3
 
 
-__version__ = '1.4'
+__version__ = '1.4.0'
 
 APP_NAME = f'MKDD Track Editor {__version__}'
 

--- a/requirements-build-linux.txt
+++ b/requirements-build-linux.txt
@@ -1,0 +1,2 @@
+cx-Freeze==6.15.16
+patchelf==0.17.2.1

--- a/requirements-build-windows.txt
+++ b/requirements-build-windows.txt
@@ -1,0 +1,3 @@
+cx-Freeze==6.15.16
+cx-Logging==3.2.0
+lief==0.14.1

--- a/setup.bat
+++ b/setup.bat
@@ -12,7 +12,7 @@ call venv/Scripts/activate.bat
 
 rem Retrieve a fresh checkout from the repository to avoid a potentially
 rem polluted local checkout.
-git clone https://github.com/RenolY2/mkdd-track-editor.git
+git clone https://github.com/RenolY2/mkdd-track-editor.git --depth=1
 cd mkdd-track-editor
 
 rem Install dependencies.

--- a/setup.bat
+++ b/setup.bat
@@ -10,15 +10,13 @@ set "PYTHONPATH="
 python -m venv venv
 call venv/Scripts/activate.bat
 
-rem Install cx_Freeze and its dependencies.
-python -m pip install cx-Freeze==6.15.16 cx-Logging==3.2.0 lief==0.14.1
-
 rem Retrieve a fresh checkout from the repository to avoid a potentially
 rem polluted local checkout.
 git clone https://github.com/RenolY2/mkdd-track-editor.git
 cd mkdd-track-editor
 
-rem Install the application's dependencies.
+rem Install dependencies.
+python -m pip install -r requirements-build-windows.txt
 python -m pip install -r requirements.txt
 
 rem Build the bundle.

--- a/setup.sh
+++ b/setup.sh
@@ -16,10 +16,8 @@ python3 -m venv venv
 source venv/bin/activate
 export PYTHONNOUSERSITE=1
 
-# Install cx_Freeze and its dependencies.
-python3 -m pip install cx-Freeze==6.15.16 patchelf==0.17.2.1
-
-# Install the application's dependencies.
+# Install dependencies.
+python3 -m pip install -r requirements-build-linux.txt
 python3 -m pip install -r requirements.txt
 
 # Build the bundle.

--- a/setup.sh
+++ b/setup.sh
@@ -6,19 +6,20 @@ rm -rf MKDDTE_BUNDLE_TMP
 mkdir MKDDTE_BUNDLE_TMP
 cd MKDDTE_BUNDLE_TMP
 
+# Create a virtual environment.
+export PYTHONNOUSERSITE=1
+unset PYTHONPATH
+python3 -m venv venv
+source venv/bin/activate
+
 # Retrieve a fresh checkout from the repository to avoid a potentially
 # polluted local checkout.
 git clone https://github.com/RenolY2/mkdd-track-editor.git --depth=1
 cd mkdd-track-editor
 
-# Create a virtual environment.
-python3 -m venv venv
-source venv/bin/activate
-export PYTHONNOUSERSITE=1
-
 # Install dependencies.
-python3 -m pip install -r requirements-build-linux.txt
-python3 -m pip install -r requirements.txt
+python -m pip install -r requirements-build-linux.txt
+python -m pip install -r requirements.txt
 
 # Build the bundle.
 python setup.py build


### PR DESCRIPTION
The preexisting `setup.py` script is used in the YAML build scripts to generate the build. The actions will be triggered by:

- Any commit pushed to the main branch (`master` currently).
- A new `vx.y.z` tag pushed to the repository.

The builds will be compressed in ZIP files, with the following naming format: `<app_name>-<version>-<sha>-<platform>-<architecture>`

For example:

- `mkdd-track-editor-1.4.0-d2f94af5-linux-x64.zip`
- `mkdd-track-editor-1.4.0-d2f94af5-windows-x64.zip`

For actions triggered by a tag creation, the commit SHA will be omitted.