### PR TITLE
Run MKDD Text Maker via Wine on Linux systems.

### DIFF
--- a/plugins/plugin_mkdd_text_maker.py
+++ b/plugins/plugin_mkdd_text_maker.py
@@ -1,12 +1,14 @@
-import subprocess
 import os
-from collections import namedtuple
+import subprocess
+import sys
+
 from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     import mkdd_editor
 
 
 class Plugin(object):
+
     def __init__(self):
         self.name = "MKDD Text Maker"
         self.actions = [("Open MKDD Text Maker", self.testfunc)]
@@ -15,7 +17,10 @@ class Plugin(object):
     def testfunc(self, editor: "mkdd_editor.GenEditor"):
         print(editor.plugins_menu.pluginfolder)
         textmaker_folder = os.path.join(editor.plugins_menu.pluginfolder, "mkdd_text_maker")
-        subprocess.Popen([os.path.join(textmaker_folder, "mkdd text maker.exe")])
+        command = [os.path.join(textmaker_folder, "mkdd text maker.exe")]
+        if sys.platform != "win32":
+            command = ["wine"] + command
+        subprocess.Popen(command)
 
     def unload(self):
         print("I have been unloaded")


### PR DESCRIPTION
On Linux system, the tool needs to be launched via `wine`, which generally works if it's available in the user's system.