### PR TITLE
Show application icon in plugin windows.

### DIFF
--- a/plugins/plugin_collision_tool.py
+++ b/plugins/plugin_collision_tool.py
@@ -102,12 +102,12 @@ class FromCollisionConverter(ClosingMdiSubWindow):
         self.autogen_path = QtWidgets.QCheckBox("Set output path based on input path", self)
         self.autogen_path.setChecked(True)
 
-        layout = QtWidgets.QVBoxLayout(self)
+        layout = QtWidgets.QVBoxLayout()
         layout.addWidget(self.input_path)
         layout.addWidget(self.output_path)
         layout.addWidget(self.autogen_path)
         layout.addWidget(self.convert_button)
-        contentwidget = QtWidgets.QWidget(self)
+        contentwidget = QtWidgets.QWidget()
 
         contentwidget.setLayout(layout)
         self.setWidget(contentwidget)
@@ -166,13 +166,13 @@ class ToCollisionConverter(ClosingMdiSubWindow):
         self.autogen_path = QtWidgets.QCheckBox("Set output path based on input path", self)
         self.autogen_path.setChecked(True)
 
-        layout = QtWidgets.QVBoxLayout(self)
+        layout = QtWidgets.QVBoxLayout()
         layout.addWidget(self.input_path)
         layout.addWidget(self.remap_path)
         layout.addWidget(self.output_path)
         layout.addWidget(self.autogen_path)
         layout.addWidget(self.convert_button)
-        contentwidget = QtWidgets.QWidget(self)
+        contentwidget = QtWidgets.QWidget()
 
         contentwidget.setLayout(layout)
         self.setWidget(contentwidget)

--- a/plugins/plugin_collision_tool.py
+++ b/plugins/plugin_collision_tool.py
@@ -224,14 +224,14 @@ class Plugin(object):
         self.to_converter_paths = [None, None, None]
 
     def open_from_converter(self, editor: "mkdd_editor.GenEditor"):
-        _ = editor
         self.from_converter = FromCollisionConverter()
+        self.from_converter.setWindowIcon(editor.windowIcon())
         self.from_converter.closing.connect(self.save_from_converter_paths)
         self.from_converter.show()
 
     def open_to_converter(self, editor: "mkdd_editor.GenEditor"):
-        _ = editor
         self.to_converter = ToCollisionConverter()
+        self.to_converter.setWindowIcon(editor.windowIcon())
         self.to_converter.closing.connect(self.save_to_converter_paths)
         self.to_converter.show()
 

--- a/plugins/plugin_rarc.py
+++ b/plugins/plugin_rarc.py
@@ -156,14 +156,14 @@ class Plugin(object):
         self.arc_extractor_paths = [None, None, None]
 
     def arc_packer_tool(self, editor: "mkdd_editor.GenEditor"):
-        _ = editor
         self.arc_packer = FolderToArc()
+        self.arc_packer.setWindowIcon(editor.windowIcon())
         self.arc_packer.closing.connect(self.save_packer_paths)
         self.arc_packer.show()
 
     def arc_extractor_tool(self, editor: "mkdd_editor.GenEditor"):
-        _ = editor
         self.arc_extractor = ArcToFolder()
+        self.arc_extractor.setWindowIcon(editor.windowIcon())
         self.arc_extractor.closing.connect(self.save_extractor_paths)
         self.arc_extractor.show()
 

--- a/plugins/plugin_rarc.py
+++ b/plugins/plugin_rarc.py
@@ -40,12 +40,12 @@ class ArcToFolder(ClosingMdiSubWindow):
         self.autogen_path = QtWidgets.QCheckBox("Set output path based on input path", self)
         self.autogen_path.setChecked(True)
 
-        layout = QtWidgets.QVBoxLayout(self)
+        layout = QtWidgets.QVBoxLayout()
         layout.addWidget(self.input_path)
         layout.addWidget(self.output_path)
         layout.addWidget(self.autogen_path)
         layout.addWidget(self.convert_button)
-        contentwidget = QtWidgets.QWidget(self)
+        contentwidget = QtWidgets.QWidget()
 
         contentwidget.setLayout(layout)
         self.setWidget(contentwidget)
@@ -102,12 +102,12 @@ class FolderToArc(ClosingMdiSubWindow):
         self.autogen_path = QtWidgets.QCheckBox("Set output path based on input path (if input ends with '_ext')", self)
         self.autogen_path.setChecked(True)
 
-        layout = QtWidgets.QVBoxLayout(self)
+        layout = QtWidgets.QVBoxLayout()
         layout.addWidget(self.input_path)
         layout.addWidget(self.output_path)
         layout.addWidget(self.autogen_path)
         layout.addWidget(self.convert_button)
-        contentwidget = QtWidgets.QWidget(self)
+        contentwidget = QtWidgets.QWidget()
 
         contentwidget.setLayout(layout)
         self.setWidget(contentwidget)


### PR DESCRIPTION
The same window icon that is used for the main window is now used also in the plugins' windows.

Bonus: The following error has been addressed too:

```
QLayout: Attempting to add QLayout "" to FolderToArc "", which already has a layout
QLayout: Attempting to add QLayout "" to ArcToFolder "", which already has a layout
QLayout: Attempting to add QLayout "" to FromCollisionConverter "", which already has a layout
QLayout: Attempting to add QLayout "" to ToCollisionConverter "", which already has a layout
```