### PR TITLE
Support rotations around X axis and Z axis in **Rotate Around Median Point** mode.

### DIFF
--- a/mkdd_editor.py
+++ b/mkdd_editor.py
@@ -3145,15 +3145,36 @@ class GenEditor(QtWidgets.QMainWindow):
 
             for position in self.level_view.selected_positions:
                 diff = position - middle
-                diff.y = 0.0
 
-                length = diff.norm()
-                if length > 0:
-                    diff.normalize()
-                    angle = atan2(diff.x, diff.z)
-                    angle += deltarotation.y
-                    position.x = middle.x + length * sin(angle)
-                    position.z = middle.z + length * cos(angle)
+                if deltarotation.x != 0:
+                    diff.x = 0.0
+                    length = diff.length()
+                    if length > 0:
+                        diff /= length
+                        angle = atan2(diff.y, diff.z)
+                        angle += -deltarotation.x
+                        position.y = middle.y + length * sin(angle)
+                        position.z = middle.z + length * cos(angle)
+
+                elif deltarotation.y != 0:
+                    diff.y = 0.0
+                    length = diff.length()
+                    if length > 0:
+                        diff /= length
+                        angle = atan2(diff.x, diff.z)
+                        angle += deltarotation.y
+                        position.x = middle.x + length * sin(angle)
+                        position.z = middle.z + length * cos(angle)
+
+                elif deltarotation.z != 0:
+                    diff.z = 0.0
+                    length = diff.length()
+                    if length > 0:
+                        diff /= length
+                        angle = atan2(diff.x, diff.y)
+                        angle += -deltarotation.z
+                        position.x = middle.x + length * sin(angle)
+                        position.y = middle.y + length * cos(angle)
 
         self.level_view.do_redraw()
         self.set_has_unsaved_changes(True)


### PR DESCRIPTION
When the **Rotate Around Median Point** mode is on, objects rotate around the median point (i.e. the position of the gizmo) as opposed to rotating around their individual origins.

Previously, only rotations around the Y axis were supported in this mode. Now, this is handled also for rotations around the X and Z axes.