### PR TITLE
Add **Purge Cache** action to purge BMD models cache.

### DIFF
--- a/lib/bmd_render.py
+++ b/lib/bmd_render.py
@@ -38,7 +38,10 @@ def superbmd_to_obj(src):
             raise RuntimeError(
                 f'BMD conversion failed (code: {process.returncode}):\n{error_output}')
 
-    shutil.copytree('lib/temp', cached_dir, dirs_exist_ok=True)
+    shutil.rmtree(cached_dir, ignore_errors=True)
+    shutil.rmtree(f'{cached_dir}_tmp', ignore_errors=True)
+    shutil.copytree('lib/temp', f'{cached_dir}_tmp')
+    os.rename(f'{cached_dir}_tmp', cached_dir)
 
 
 def clear_temp_folder():

--- a/lib/bmd_render.py
+++ b/lib/bmd_render.py
@@ -7,13 +7,16 @@ import tempfile
 from lib.model_rendering import TexturedModel
 
 
+mkdd_editor_cache_dir = os.path.join(tempfile.gettempdir(), 'mkdd_track_editor_cache')
+
+
 def md5sum(filepath: str) -> str:
     return hashlib.md5(open(filepath, 'rb').read()).hexdigest()
 
 
 def superbmd_to_obj(src):
     checksum = md5sum(src)
-    cached_dir = os.path.join(tempfile.gettempdir(), f'mkdd_track_editor_tmp_{checksum}')
+    cached_dir = os.path.join(mkdd_editor_cache_dir, checksum)
 
     if os.path.isdir(cached_dir) and os.path.exists(os.path.join(cached_dir, "temp.obj")):
         shutil.rmtree('lib/temp')

--- a/mkdd_editor.py
+++ b/mkdd_editor.py
@@ -9,6 +9,7 @@ import enum
 import pickle
 import platform
 import pstats
+import shutil
 import textwrap
 import traceback
 import weakref
@@ -51,7 +52,7 @@ from lib.model_rendering import TexturedModel, CollisionModel, Minimap
 from widgets.editor_widgets import ErrorAnalyzer, ErrorAnalyzerButton, show_minimap_generator
 from lib.dolreader import DolFile, read_float, write_float, read_load_immediate_r0, write_load_immediate_r0, UnmappedAddress
 from widgets.file_select import FileSelect
-from lib.bmd_render import clear_temp_folder, load_textured_bmd
+from lib.bmd_render import clear_temp_folder, load_textured_bmd, mkdd_editor_cache_dir
 from lib.game_visualizer import Game
 from lib.vectors import Vector3
 
@@ -855,6 +856,9 @@ class GenEditor(QtWidgets.QMainWindow):
         self.clear_current_collision.triggered.connect(self.clear_collision)
         self.collision_menu.addAction(self.clear_current_collision)
 
+        self.collision_menu.addSeparator()
+        purge_cache_action = self.collision_menu.addAction("Purge Cache")
+        purge_cache_action.triggered.connect(self.on_purge_cache_triggered)
         self.collision_menu.addSeparator()
         cull_faces_action = self.collision_menu.addAction("Cull Faces")
         cull_faces_action.setCheckable(True)
@@ -1667,6 +1671,9 @@ class GenEditor(QtWidgets.QMainWindow):
         save_cfg(self.configuration)
 
         self.level_view.do_redraw()
+
+    def on_purge_cache_triggered(self):
+        shutil.rmtree(mkdd_editor_cache_dir)
 
     def on_cull_faces_triggered(self, checked):
         self.editorconfig["cull_faces"] = "True" if checked else "False"


### PR DESCRIPTION
An action has been added in the **Geometry** top menu bar to purge the converted BMD models that MKDD Track Editor caches for improving loading times:

![Geometry > Purge Cache](https://github.com/user-attachments/assets/70ceffd5-a877-4889-b610-b4f0a9a2fb69)

This allows users to purge the cache in the event of a conversion by SuperBMD going wrong.

Also, cached models are now stored in `<system_temporary_directory>/mkdd_track_editor_cache`, which each entry in that directory named after the checksum of the BMD file.