### PR TITLE
Copy `EnemyPoint` objects with custom `copy()` function.

### DIFF
--- a/lib/libbol.py
+++ b/lib/libbol.py
@@ -466,7 +466,7 @@ class EnemyPointGroup(object):
         group = EnemyPointGroup()
         group.id = new_id
         for point in self.points:
-            new_point = deepcopy(point)
+            new_point = point.copy()
             new_point.group = new_id
             group.points.append(new_point)
 
@@ -485,7 +485,7 @@ class EnemyPointGroup(object):
                     tmp = point.widget
                     point.widget = None
 
-                new_point = deepcopy(point)
+                new_point = point.copy()
 
                 if hasattr(point, "widget"):
                     point.widget = tmp
@@ -675,7 +675,7 @@ class CheckpointGroup(object):
         group.nextgroup = deepcopy(self.nextgroup)
 
         for point in self.points:
-            new_point = deepcopy(point)
+            new_point = point.copy()
             group.points.append(new_point)
 
         return group
@@ -687,7 +687,7 @@ class CheckpointGroup(object):
         # Check if the element is the last element
         if not len(self.points)-1 == pos:
             for point in self.points[pos+1:]:
-                new_point = deepcopy(point)
+                new_point = point.copy()
                 group.points.append(new_point)
 
         return group


### PR DESCRIPTION
The **Duplicate** action in the tree view used the built-in `deepcopy()` Python function to clone `EnemyPoint` objects. However, since 7178d89, the class hows a Qt widget object that is not _pickable_, leading to an exception if tried:

```counterexample
Traceback (most recent call last):
  File ".../mkdd_editor.py", line 1990, in duplicate_group
    new_group = group.copy_group(new_id)
                ^^^^^^^^^^^^^^^^^^^^^^^^
  File ".../lib/libbol.py", line 469, in copy_group
    new_point = deepcopy(point)
                ^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/copy.py", line 162, in deepcopy
    y = _reconstruct(x, memo, *rv)
        ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/copy.py", line 259, in _reconstruct
    state = deepcopy(state, memo)
            ^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/copy.py", line 136, in deepcopy
    y = copier(x, memo)
        ^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/copy.py", line 221, in _deepcopy_dict
    y[deepcopy(key, memo)] = deepcopy(value, memo)
                             ^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/copy.py", line 151, in deepcopy
    rv = reductor(4)
         ^^^^^^^^^^^
TypeError: cannot pickle 'EnemyRoutePoint' object
```

After that exception, the application goes bad, with a spam of other mysterious exceptions such as:

```counterexample
Traceback (most recent call last):
  File "/w/mkdd-track-editor/widgets/editor_widgets.py", line 24, in handle
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/w/mkdd-track-editor/mkdd_widgets.py", line 1572, in mouseMoveEvent
    self.usercontrol.handle_move(event)
  File "/w/mkdd-track-editor/editor_controls.py", line 695, in handle_move
    self.handle_move_topdown(event)
  File "/w/mkdd-track-editor/editor_controls.py", line 723, in handle_move_topdown
    if self.buttons.is_held(event, key):
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/w/mkdd-track-editor/editor_controls.py", line 38, in is_held
    self._buttons[key] = event.buttons() & key_enums[key]
                         ^^^^^^^^^^^^^
AttributeError: 'PySide6.QtGui.QContextMenuEvent' object has no attribute 'buttons'
```

The solution is to use `EnemyPoint.copy()` which, correctly handles the widget object but stashing it away temporarily.