### PR TITLE
Sync RGB color labels in **Minimap Generator**.

### DIFF
--- a/widgets/editor_widgets.py
+++ b/widgets/editor_widgets.py
@@ -815,10 +815,17 @@ def show_minimap_generator(editor: 'GenEditor'):
     color_mode_blackwhite_radiobutton.toggled.connect(lambda checked: update() if checked else None)
     color_mode_customcolors_radiobutton.toggled.connect(lambda checked: update()
                                                         if checked else None)
-    for visible_checkbox, color_picker, _color_picker_label in terrain_colors_widgets_map.values():
+    for visible_checkbox, color_picker, color_picker_label in terrain_colors_widgets_map.values():
         visible_checkbox.stateChanged.connect(lambda _state: update())
         color_picker.color_changed.connect(update)
         color_picker.color_picked.connect(update)
+        color_picker.color_changed.connect(
+            lambda color, picker=color_picker_label: picker.setText(
+                '({}, {}, {})'.format(
+                    color.red(),
+                    color.green(),
+                    color.blue(),
+                )))
     reset_button.clicked.connect(reset)
 
     update()


### PR DESCRIPTION
The custom colors that can be used in the **Minimap Generator** show a RGB color label with the numeric values:

<img width="480" alt="RGB color labels in Minimap Generator" title="RGB color labels in Minimap Generator" src="https://github.com/user-attachments/assets/bbdf3285-5bd0-4576-bd09-a282c6a2a79e" />

Until now, the color label would not update as the user changed the color in the color picker.